### PR TITLE
fix(ux): refine tree navigation, links, and mobile shell

### DIFF
--- a/crates/miku-app/src/application.rs
+++ b/crates/miku-app/src/application.rs
@@ -340,7 +340,7 @@ impl VaultReader for FileMikuApplication {
         };
         let pages = self
             .index
-            .list_pages_under(&prefix)
+            .list_tree_pages(&prefix)
             .await
             .map_err(ApplicationError::from)?;
         Ok(FileTree {

--- a/crates/miku-app/src/lib.rs
+++ b/crates/miku-app/src/lib.rs
@@ -179,6 +179,11 @@ impl IndexApi {
         self.reader.list_pages_under(prefix).await
     }
 
+    /// Return the minimal projection required for one lazy tree level.
+    pub async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        self.reader.list_tree_pages(prefix).await
+    }
+
     /// Load one page summary.
     pub async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>> {
         self.reader.page(path).await

--- a/crates/miku-domain/src/lib.rs
+++ b/crates/miku-domain/src/lib.rs
@@ -268,6 +268,13 @@ pub trait IndexReader: Send + Sync {
         })
     }
 
+    /// Return only the indexed rows needed to build one lazy tree level:
+    /// direct Markdown files plus one representative descendant per child
+    /// folder. Backends may override this to avoid loading every descendant.
+    async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        self.list_pages_under(prefix).await
+    }
+
     /// Load one indexed page summary, if it exists.
     async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>>;
 

--- a/crates/miku-index-sqlite/src/lib.rs
+++ b/crates/miku-index-sqlite/src/lib.rs
@@ -184,6 +184,61 @@ impl IndexReader for SqliteIndex {
         Ok(summaries)
     }
 
+    async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        let escaped_prefix = prefix
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let rows = sqlx::query_as::<_, (String, String, String, i64)>(
+            "WITH scoped AS (
+                 SELECT path,
+                        CASE
+                            WHEN instr(substr(path, length(?) + 1), '/') = 0
+                                THEN substr(path, length(?) + 1)
+                            ELSE substr(
+                                substr(path, length(?) + 1),
+                                1,
+                                instr(substr(path, length(?) + 1), '/') - 1
+                            )
+                        END AS child
+                 FROM tb_pages
+                 WHERE path LIKE ? ESCAPE '\\'
+             ),
+             selected AS (
+                 SELECT min(path) AS path
+                 FROM scoped
+                 GROUP BY child
+             )
+             SELECT page.path, page.title, page.frontmatter, page.mtime
+             FROM tb_pages AS page
+             JOIN selected ON selected.path = page.path
+             ORDER BY page.title, page.path",
+        )
+        .bind(prefix)
+        .bind(prefix)
+        .bind(prefix)
+        .bind(prefix)
+        .bind(format!("{escaped_prefix}%"))
+        .fetch_all(self.pool())
+        .await
+        .map_err(database_error)?;
+
+        let mut summaries = Vec::with_capacity(rows.len());
+        for (path, title, frontmatter_str, mtime) in rows {
+            let frontmatter: serde_json::Value = serde_json::from_str(&frontmatter_str)
+                .map_err(|e| StoreError::Operation(format!("invalid frontmatter JSON: {e}")))?;
+            let aliases = frontmatter_aliases(&frontmatter);
+            summaries.push(PageSummary {
+                path,
+                title,
+                frontmatter,
+                mtime,
+                aliases,
+            });
+        }
+        Ok(summaries)
+    }
+
     async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>> {
         let row = sqlx::query_as::<_, (String, String, String, i64)>(
             "SELECT path, title, frontmatter, mtime FROM tb_pages WHERE path = ?",
@@ -836,6 +891,7 @@ mod tests {
             .replace_pages(vec![
                 test_page("folder/One.md", "one", vec![], vec![]),
                 test_page("folder/nested/Two.md", "two", vec![], vec![]),
+                test_page("folder/nested/Three.md", "three nested", vec![], vec![]),
                 test_page("other/Three.md", "three", vec![], vec![]),
                 test_page("folder-sibling/Four.md", "four", vec![], vec![]),
             ])
@@ -848,13 +904,42 @@ mod tests {
             .expect("list pages under folder/");
         let mut scoped_paths: Vec<_> = scoped.iter().map(|page| page.path.clone()).collect();
         scoped_paths.sort();
-        assert_eq!(scoped_paths, vec!["folder/One.md", "folder/nested/Two.md"]);
+        assert_eq!(
+            scoped_paths,
+            vec![
+                "folder/One.md",
+                "folder/nested/Three.md",
+                "folder/nested/Two.md"
+            ]
+        );
+
+        let tree_pages = store
+            .list_tree_pages("folder/")
+            .await
+            .expect("list one folder tree level");
+        assert_eq!(tree_pages.len(), 2);
+        assert!(tree_pages.iter().any(|page| page.path == "folder/One.md"));
+        assert_eq!(
+            tree_pages
+                .iter()
+                .filter(|page| page.path.starts_with("folder/nested/"))
+                .count(),
+            1
+        );
 
         let all = store
             .list_pages_under("")
             .await
             .expect("empty prefix lists everything");
-        assert_eq!(all.len(), 4);
+        assert_eq!(all.len(), 5);
+        assert_eq!(
+            store
+                .list_tree_pages("")
+                .await
+                .expect("list root tree level")
+                .len(),
+            3
+        );
 
         let none = store
             .list_pages_under("nonexistent/")

--- a/crates/miku-indexer/src/lib.rs
+++ b/crates/miku-indexer/src/lib.rs
@@ -28,6 +28,10 @@ static EXTERNAL_LINK_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::ne
     Regex::new(r"^[a-zA-Z][a-zA-Z\d+.-]*:").expect("external link regex")
 });
 
+static CODE_RANGE_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"(?s)```.*?```|~~~.*?~~~|`[^`\n]*`").expect("code range regex")
+});
+
 /// Mirrors the frontend's `/^[a-z][a-z\d+.-]*:/i` scheme-prefix check
 /// (`noteLinks.ts`) so external URLs (`https:`, `mailto:`, ...) are never
 /// treated as page/asset targets.
@@ -48,9 +52,19 @@ pub fn build_page_index(path: &str, raw: &[u8], mtime: i64) -> PageIndex {
             text: heading.text,
         })
         .collect();
+    let code_ranges = CODE_RANGE_REGEX
+        .find_iter(body)
+        .map(|matched| matched.start()..matched.end())
+        .collect::<Vec<_>>();
 
     let mut links: Vec<LinkRecord> = WIKILINK_REGEX
         .captures_iter(body)
+        .filter(|capture| {
+            let matched = capture.get(0).expect("wikilink capture has a full match");
+            !code_ranges
+                .iter()
+                .any(|range| range.start <= matched.start() && matched.end() <= range.end)
+        })
         .map(|capture| {
             let target = capture[2].trim().to_string();
             let is_embed = !capture[1].is_empty();
@@ -73,6 +87,14 @@ pub fn build_page_index(path: &str, raw: &[u8], mtime: i64) -> PageIndex {
     links.extend(
         MARKDOWN_LINK_REGEX
             .captures_iter(body)
+            .filter(|capture| {
+                let matched = capture
+                    .get(0)
+                    .expect("markdown link capture has a full match");
+                !code_ranges
+                    .iter()
+                    .any(|range| range.start <= matched.start() && matched.end() <= range.end)
+            })
             .filter_map(|capture| {
                 let target = capture[3].trim().to_string();
                 if target.is_empty() || target.starts_with('#') || is_external_link(&target) {
@@ -228,6 +250,19 @@ mod tests {
             .unwrap();
         assert!(embed.is_embed);
         assert_eq!(embed.kind, LinkKind::Asset);
+    }
+
+    #[test]
+    fn skips_links_inside_fenced_and_inline_code() {
+        let page = build_page_index(
+            "Code.md",
+            b"```markdown\n[wikilinks](/p/wikilinks.md)\n[[fenced-wikilink]]\n```\n~~~md\n[tilde](/p/tilde.md)\n~~~\n`[inline](/p/inline.md)`\n[Visible](/p/visible.md)",
+            1,
+        );
+
+        assert_eq!(page.links.len(), 1);
+        assert_eq!(page.links[0].target, "/p/visible.md");
+        assert_eq!(page.links[0].alias.as_deref(), Some("Visible"));
     }
 
     #[test]

--- a/crates/miku/src/http_api.rs
+++ b/crates/miku/src/http_api.rs
@@ -229,9 +229,14 @@ pub async fn tree(
         .file_tree(FileTreeRequest { folder })
         .await
         .map_err(application_error)?;
+    let parent_id = tree_parent_id(&tree.folder, query.parent_id.clone());
     Ok(Json(TreeResponse {
-        parent_id: query.parent_id.clone(),
-        nodes: tree.nodes.into_iter().map(tree_node).collect(),
+        parent_id: parent_id.clone(),
+        nodes: tree
+            .nodes
+            .into_iter()
+            .map(|node| tree_node_with_parent(node, parent_id.clone()))
+            .collect(),
     }))
 }
 
@@ -434,15 +439,18 @@ fn application_error(error: ApplicationError) -> AppError {
     }
 }
 
-fn tree_node(node: FileNode) -> TreeNode {
-    tree_node_with_parent(node, None)
+fn tree_parent_id(folder: &RelativePath, compatibility_parent: Option<String>) -> Option<String> {
+    if folder.as_str().is_empty() {
+        compatibility_parent
+    } else {
+        Some(folder.as_str().to_string())
+    }
 }
 
 /// Builds a `TreeNode`, tagging it with `parent_id` when the caller knows
 /// it (e.g. mapping a note's `children` to entries parented by that note --
 /// `FileNode` itself carries no parent reference, so this can't be derived
-/// from `node` alone). `/api/v1/tree`'s root/folder-scoped nodes have no
-/// such relationship yet and keep using `tree_node` (`parent_id`: None).
+/// from `node` alone).
 fn tree_node_with_parent(node: FileNode, parent_id: Option<String>) -> TreeNode {
     let note_id = node
         .note_id
@@ -634,10 +642,11 @@ mod tests {
     }
 
     #[test]
-    fn tree_node_has_no_parent_by_default() {
-        // /api/v1/tree's root/folder-scoped nodes have no known parent
-        // note relationship yet.
-        assert_eq!(tree_node(file_node("Notes/N1.md")).parent_id, None);
+    fn root_tree_node_has_no_parent() {
+        assert_eq!(
+            tree_node_with_parent(file_node("Notes/N1.md"), None).parent_id,
+            None
+        );
     }
 
     #[test]
@@ -647,5 +656,15 @@ mod tests {
         // None in every response regardless of the actual relationship.
         let node = tree_node_with_parent(file_node("Notes/Child.md"), Some("parent-1".to_string()));
         assert_eq!(node.parent_id, Some("parent-1".to_string()));
+    }
+
+    #[test]
+    fn folder_scoped_tree_applies_parent_to_the_response_and_every_child() {
+        let folder = RelativePath::new("geektime-docs/AI-\u{5927}\u{6570}\u{636e}").unwrap();
+        assert_eq!(
+            tree_parent_id(&folder, None),
+            Some("geektime-docs/AI-\u{5927}\u{6570}\u{636e}".to_string())
+        );
+        assert_eq!(tree_parent_id(&RelativePath::root(), None), None);
     }
 }

--- a/miku-web/index.html
+++ b/miku-web/index.html
@@ -7,7 +7,7 @@
     <meta name="application-name" content="Miku Note" />
     <link id="miku-favicon" rel="icon" type="image/svg+xml" href="/miku-icon-light.svg" />
     <title>Miku Note</title>
-    <script>document.getElementById('miku-favicon').href = matchMedia('(prefers-color-scheme: dark)').matches ? '/miku-icon-dark.svg' : '/miku-icon-light.svg';</script>
+    <script>document.getElementById('miku-favicon').href = (localStorage.getItem('miku:ui:v2') || localStorage.getItem('miku-theme')) === 'light' ? '/miku-icon-light.svg' : '/miku-icon-dark.svg';</script>
   </head>
   <body>
     <div id="root"></div>

--- a/miku-web/src/components/workspace/WorkspaceTree.test.tsx
+++ b/miku-web/src/components/workspace/WorkspaceTree.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TreeNodeModel } from "../../features/workspace/api";
+import { EXPLORER_STATE_KEY } from "../../shared/ui";
+import { WorkspaceTree } from "./WorkspaceTree";
+
+function folder(path: string): TreeNodeModel {
+  return {
+    kind: "folder",
+    path,
+    hasChildren: true,
+    placementId: `path:${path}`,
+    noteId: path,
+    parentId: null,
+    note: {
+      id: path,
+      path,
+      title: path.split("/").at(-1) ?? path,
+      identityGenerated: false,
+      parents: [],
+      aliases: []
+    }
+  };
+}
+
+function markdown(path: string): TreeNodeModel {
+  return {
+    ...folder(path),
+    kind: "markdown",
+    hasChildren: false
+  };
+}
+
+describe("WorkspaceTree", () => {
+  it("reopens a globally collapsed tree when a folder is clicked once", async () => {
+    const tree = vi.fn().mockResolvedValue([folder("dedao-docs/docs"), markdown("dedao-docs/README.md")]);
+    const rootNodes = [folder("dedao-docs")];
+    localStorage.setItem(EXPLORER_STATE_KEY, JSON.stringify(["dedao-docs"]));
+
+    function CollapsedTree() {
+      const [hoisted, setHoisted] = useState(true);
+      return <WorkspaceTree notes={[]} nodes={rootNodes} activeId="" onSelect={() => undefined} hoisted={hoisted} onExpandTree={() => setHoisted(false)} client={{ tree } as never} />;
+    }
+
+    render(<CollapsedTree />);
+    fireEvent.click(screen.getByRole("button", { name: "dedao-docs" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "docs" })).toBeTruthy());
+    expect(screen.getByRole("button", { name: "README.md" })).toBeTruthy();
+    expect(tree).toHaveBeenCalledWith("dedao-docs");
+    localStorage.clear();
+  });
+});

--- a/miku-web/src/components/workspace/WorkspaceTree.tsx
+++ b/miku-web/src/components/workspace/WorkspaceTree.tsx
@@ -9,6 +9,7 @@ export function WorkspaceTree({
   activeId,
   onSelect,
   hoisted,
+  onExpandTree,
   client
 }: {
   notes: NoteModel[];
@@ -16,6 +17,7 @@ export function WorkspaceTree({
   activeId: string;
   onSelect: (id: string) => void;
   hoisted: boolean;
+  onExpandTree: () => void;
   client: ReturnType<typeof createWorkspaceClient>;
 }) {
   const noteMap = useMemo(() => new Map(notes.map((note) => [note.id, note])), [notes]);
@@ -24,7 +26,7 @@ export function WorkspaceTree({
     return new Set(persisted.filter((path) => !persisted.some((parent) => parent !== path && path.startsWith(`${parent}/`))));
   });
   const [loaded, setLoaded] = useState<Record<string, TreeNodeModel[]>>({});
-  const roots = sortTreeNodes(nodes.filter((node) => node.parentId === null));
+  const roots = useMemo(() => sortTreeNodes(nodes.filter((node) => node.parentId === null)), [nodes]);
 
   useEffect(() => {
     if (!activeId || hoisted) return;
@@ -69,6 +71,10 @@ export function WorkspaceTree({
     const indexNote = children.find((child) => child.kind === "markdown" && child.path === `${node.path}/index.md`);
     const title = isFolder ? (indexNote?.note.title ?? node.note.title) : note.title;
     const toggleFolder = async () => {
+      if (hoisted) {
+        onExpandTree();
+        if (isExpanded) return;
+      }
       if (isExpanded) {
         setExpanded((current) => new Set([...current].filter((path) => path !== node.path)));
         return;

--- a/miku-web/src/components/workspace/icons.tsx
+++ b/miku-web/src/components/workspace/icons.tsx
@@ -10,6 +10,7 @@ import { FileText } from "@phosphor-icons/react/dist/icons/FileText";
 import { Folder } from "@phosphor-icons/react/dist/icons/Folder";
 import { GearSix } from "@phosphor-icons/react/dist/icons/GearSix";
 import { Hash } from "@phosphor-icons/react/dist/icons/Hash";
+import { List } from "@phosphor-icons/react/dist/icons/List";
 import { MagnifyingGlass } from "@phosphor-icons/react/dist/icons/MagnifyingGlass";
 import { Moon } from "@phosphor-icons/react/dist/icons/Moon";
 import { Rocket } from "@phosphor-icons/react/dist/icons/Rocket";
@@ -18,7 +19,7 @@ import { TreeStructure } from "@phosphor-icons/react/dist/icons/TreeStructure";
 import { X } from "@phosphor-icons/react/dist/icons/X";
 import type { Icon } from "@phosphor-icons/react";
 
-export type ActionIconName = "arrow-up" | "arrow-up-right" | "chevron-down" | "chevron-left" | "chevron-right" | "close" | "hash" | "moon" | "search" | "settings" | "sun" | "tree" | "clock";
+export type ActionIconName = "arrow-up" | "arrow-up-right" | "chevron-down" | "chevron-left" | "chevron-right" | "close" | "hash" | "menu" | "moon" | "search" | "settings" | "sun" | "tree" | "clock";
 
 export function ActionIcon({ name }: { name: ActionIconName }) {
   const icons: Record<ActionIconName, Icon> = {
@@ -29,6 +30,7 @@ export function ActionIcon({ name }: { name: ActionIconName }) {
     "chevron-right": CaretRight,
     close: X,
     hash: Hash,
+    menu: List,
     moon: Moon,
     search: MagnifyingGlass,
     settings: GearSix,

--- a/miku-web/src/features/markdown/noteLinks.test.ts
+++ b/miku-web/src/features/markdown/noteLinks.test.ts
@@ -81,5 +81,12 @@ describe("extractOutgoingLinks", () => {
       { path: "vault/maps/uncreated-note.md", title: "uncreated-note", isMissing: true }
     ]);
   });
-});
 
+  it("ignores links inside fenced and inline code", () => {
+    const body = ["```markdown", "[wikilinks](/p/wikilinks.md)", "[[fenced-wikilink]]", "```", "~~~md", "[tilde](/p/tilde.md)", "~~~", "`[inline](/p/inline.md)`", "[visible](/p/visible.md)"].join(
+      "\n"
+    );
+
+    expect(extractOutgoingLinks(body)).toEqual([{ path: "visible.md", title: "visible", isMissing: true }]);
+  });
+});

--- a/miku-web/src/features/markdown/noteLinks.ts
+++ b/miku-web/src/features/markdown/noteLinks.ts
@@ -1,6 +1,10 @@
 export type NoteCandidate = { id?: string; path: string; title?: string; aliases?: string[] };
 export type TargetResolver = (target: string) => string | null;
 
+function proseSegments(markdown: string): string[] {
+  return markdown.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)/g).filter((_, index) => index % 2 === 0);
+}
+
 export function isAssetFile(path: string): boolean {
   const lower = path.trim().toLowerCase();
   return (
@@ -171,17 +175,17 @@ export function extractOutgoingLinks(body: string, notes?: NoteCandidate[], curr
     results.push({ path: finalPath, title, isMissing });
   };
 
+  for (const segment of proseSegments(body)) {
+    // 1. [[wikilink|label]]
+    for (const match of segment.matchAll(/(?<!!)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g)) {
+      addLink(match[1], match[2]);
+    }
 
-  // 1. [[wikilink|label]]
-  for (const match of body.matchAll(/(?<!!)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g)) {
-    addLink(match[1], match[2]);
-  }
-
-  // 2. [label](/p/target) or [label](target.md)
-  for (const match of body.matchAll(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/g)) {
-    addLink(match[2], match[1]);
+    // 2. [label](/p/target) or [label](target.md)
+    for (const match of segment.matchAll(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/g)) {
+      addLink(match[2], match[1]);
+    }
   }
 
   return results;
 }
-

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -17,6 +17,7 @@ export function WorkspaceScreen() {
   const [searchScope, setSearchScope] = useState<SearchScope>("all");
   const [searchSelection, setSearchSelection] = useState(-1);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => Number(localStorage.getItem("miku-sidebar-width") ?? 244));
   const [contextWidth, setContextWidth] = useState(() => Number(localStorage.getItem("miku-context-width") ?? 235));
   const [notice, setNotice] = useState<string | null>(null);
@@ -24,6 +25,7 @@ export function WorkspaceScreen() {
   const [apiSource, setApiSource] = useState<ApiSource>("connecting");
   const [theme, setTheme] = useState<Theme>(readTheme);
   const searchPanelRef = useRef<HTMLDivElement>(null);
+  const mobileNavButtonRef = useRef<HTMLButtonElement>(null);
   const resizingSidebar = useRef(false);
   const resizingContext = useRef(false);
   const navigate = useNavigate();
@@ -206,6 +208,19 @@ export function WorkspaceScreen() {
   useEffect(() => {
     localStorage.setItem("miku-context-width", String(contextWidth));
   }, [contextWidth]);
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setMobileNavOpen(false);
+      mobileNavButtonRef.current?.focus();
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [mobileNavOpen]);
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (!searchOpen) return;
@@ -286,7 +301,14 @@ export function WorkspaceScreen() {
   const secondaryNote = notes.find((candidate) => candidate.id === (state.tabs.find((tab) => tab !== activeId) ?? "welcome")) ?? activeNote;
   return (
     <div className="app-shell flex h-screen min-h-0 flex-col bg-miku-bg text-miku-text" data-theme={theme} data-ui-state-version={UI_STATE_VERSION}>
-      <LaunchBar onSearch={openSearch} theme={theme} onToggleTheme={toggleTheme} />
+      <LaunchBar
+        onSearch={openSearch}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        mobileNavOpen={mobileNavOpen}
+        onToggleMobileNav={() => setMobileNavOpen((current) => !current)}
+        mobileNavButtonRef={mobileNavButtonRef}
+      />
       {searchOpen && (
         <div className="search-popover" ref={searchPanelRef} data-region="quick-open">
           <div className="search-popover-head">
@@ -363,6 +385,16 @@ export function WorkspaceScreen() {
         </div>
       )}
       <WorkspaceNotice message={notice} onDismiss={() => setNotice(null)} />
+      {mobileNavOpen && (
+        <button
+          className="mobile-nav-backdrop"
+          aria-label="Close workspace navigation"
+          onClick={() => {
+            setMobileNavOpen(false);
+            mobileNavButtonRef.current?.focus();
+          }}
+        />
+      )}
       <div
         className="workspace-layout flex h-[calc(100vh-var(--shell-topbar-height))] min-h-0 overflow-hidden"
         style={{ "--shell-sidebar-width": `${sidebarWidth}px`, "--shell-context-width": `${contextWidth}px` } as React.CSSProperties}
@@ -379,6 +411,11 @@ export function WorkspaceScreen() {
           onRecent={() => navigate("/recent")}
           onSettings={() => setSettingsOpen(true)}
           noteCount={workspace.data?.noteCount ?? 0}
+          mobileOpen={mobileNavOpen}
+          onCloseMobile={() => {
+            setMobileNavOpen(false);
+            mobileNavButtonRef.current?.focus();
+          }}
           onResizeStart={(event) => {
             event.preventDefault();
             resizingSidebar.current = true;

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -47,6 +47,12 @@ export function WorkspaceScreen() {
   const workspace = useQuery({ queryKey: ["workspace"], queryFn: client.workspace });
   const tree = useQuery({ queryKey: ["tree"], queryFn: () => client.tree() });
   const folder = useQuery({ queryKey: ["folder", folderPath], queryFn: () => client.tree(folderPath), enabled: Boolean(folderPath) });
+
+  useEffect(() => {
+    const favicon = document.querySelector<HTMLLinkElement>("#miku-favicon");
+    if (favicon) favicon.href = `/miku-icon-${theme}.svg`;
+  }, [theme]);
+
   const context = useQuery({
     queryKey: ["context", activeId],
     queryFn: () => client.context(activeId),

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -26,10 +26,34 @@ function noteHeadings(markdown: string): { id: string; text: string; level: numb
   return headings;
 }
 
-export function LaunchBar({ onSearch, theme, onToggleTheme }: { onSearch: () => void; theme: "dark" | "light"; onToggleTheme: () => void }) {
+export function LaunchBar({
+  onSearch,
+  theme,
+  onToggleTheme,
+  mobileNavOpen,
+  onToggleMobileNav,
+  mobileNavButtonRef
+}: {
+  onSearch: () => void;
+  theme: "dark" | "light";
+  onToggleTheme: () => void;
+  mobileNavOpen: boolean;
+  onToggleMobileNav: () => void;
+  mobileNavButtonRef: React.RefObject<HTMLButtonElement | null>;
+}) {
   const navigate = useNavigate();
   return (
     <header className="launch-bar" data-region={shellRegions[0]}>
+      <button
+        ref={mobileNavButtonRef}
+        className="quiet-button mobile-nav-toggle"
+        aria-label={mobileNavOpen ? "Close workspace navigation" : "Open workspace navigation"}
+        aria-controls="workspace-navigation"
+        aria-expanded={mobileNavOpen}
+        onClick={onToggleMobileNav}
+      >
+        <ActionIcon name={mobileNavOpen ? "close" : "menu"} />
+      </button>
       <button className="brand-mark" onClick={() => navigate("/")} aria-label="Go to workspace home">
         <img className="brand-icon" src={`/miku-icon-${theme}.svg`} alt="" />
         <span>miku note</span>
@@ -60,7 +84,9 @@ export function Sidebar({
   onRecent,
   onSettings,
   noteCount,
-  onResizeStart
+  onResizeStart,
+  mobileOpen,
+  onCloseMobile
 }: {
   notes: NoteModel[];
   nodes: TreeNodeModel[];
@@ -74,12 +100,17 @@ export function Sidebar({
   onSettings: () => void;
   noteCount: number;
   onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  mobileOpen: boolean;
+  onCloseMobile: () => void;
 }) {
   return (
-    <aside className="sidebar" data-region={shellRegions[1]}>
+    <aside id="workspace-navigation" className={`sidebar ${mobileOpen ? "is-mobile-open" : ""}`} data-region={shellRegions[1]} aria-label="Workspace navigation">
       <button className="sidebar-resizer" onPointerDown={onResizeStart} aria-label="Resize workspace navigation" />
       <div className="sidebar-toolbar">
         <span className="eyebrow">Workspace</span>
+        <button className="tool-button mobile-nav-close" onClick={onCloseMobile} aria-label="Close workspace navigation">
+          <ActionIcon name="close" />
+        </button>
         <button
           className={`tool-button ${hoisted ? "is-on" : ""}`}
           onClick={onToggleHoist}

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -94,7 +94,7 @@ export function Sidebar({
         <span>All notes</span>
         <span className="count-pill">{noteCount}</span>
       </div>
-      <WorkspaceTree notes={notes} nodes={nodes} activeId={activeId} onSelect={onSelect} hoisted={hoisted} client={client} />
+      <WorkspaceTree notes={notes} nodes={nodes} activeId={activeId} onSelect={onSelect} hoisted={hoisted} onExpandTree={onToggleHoist} client={client} />
       <div className="sidebar-bottom">
         <button className="sidebar-link" onClick={onRecent}>
           <ActionIcon name="clock" /> Recent

--- a/miku-web/src/styles.css
+++ b/miku-web/src/styles.css
@@ -75,6 +75,22 @@
 }
 * {
   box-sizing: border-box;
+  scrollbar-color: color-mix(in srgb, var(--faint) 62%, transparent) transparent;
+  scrollbar-width: thin;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+  background: transparent;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--faint) 62%, transparent);
+  background-clip: content-box;
 }
 body {
   margin: 0;
@@ -114,6 +130,7 @@ input:focus-visible {
   font-size: 1.15em;
 }
 .app-shell {
+  color-scheme: dark;
   color: var(--text);
   background: var(--bg);
 }
@@ -249,6 +266,11 @@ input:focus-visible {
 .quiet-button:hover,
 .tool-button:hover {
   color: var(--text);
+}
+.mobile-nav-toggle,
+.mobile-nav-close,
+.mobile-nav-backdrop {
+  display: none;
 }
 .workspace-layout {
 }
@@ -1542,6 +1564,28 @@ input:focus-visible {
   .brand-mark {
     width: auto;
   }
+  .brand-mark span {
+    display: none;
+  }
+  .mobile-nav-toggle,
+  .mobile-nav-close {
+    display: inline-flex;
+  }
+  .mobile-nav-toggle {
+    flex: 0 0 auto;
+  }
+  .mobile-nav-backdrop {
+    display: block;
+    position: fixed;
+    z-index: 19;
+    inset: var(--shell-topbar-height) 0 0;
+    width: 100%;
+    height: auto;
+    border: 0;
+    border-radius: 0;
+    background: rgb(0 0 0 / 42%);
+    backdrop-filter: blur(2px);
+  }
   .workspace-source {
     display: none;
   }
@@ -1552,7 +1596,29 @@ input:focus-visible {
     display: none;
   }
   .sidebar {
-    flex-basis: 200px;
+    position: fixed;
+    z-index: 20;
+    top: var(--shell-topbar-height);
+    bottom: 0;
+    left: 0;
+    width: min(84vw, 320px);
+    max-width: 320px;
+    flex-basis: auto;
+    box-shadow: 16px 0 40px rgb(0 0 0 / 24%);
+    transform: translateX(-105%);
+    transition: transform 160ms ease;
+  }
+  .sidebar.is-mobile-open {
+    transform: translateX(0);
+  }
+  .sidebar-resizer {
+    display: none;
+  }
+  .sidebar-toolbar {
+    gap: 6px;
+  }
+  .sidebar-toolbar .mobile-nav-close {
+    order: 2;
   }
   .context-panel {
     display: none;
@@ -1579,6 +1645,11 @@ input:focus-visible {
   }
   .note-pane.is-split {
     min-width: 0;
+  }
+}
+@media (max-width: 760px) and (prefers-reduced-motion: reduce) {
+  .sidebar {
+    transition: none;
   }
 }
 [data-theme="light"] {
@@ -1608,6 +1679,9 @@ input:focus-visible {
   --reader-border: #e9e9e7;
   --reader-muted: #787774;
   --relation: #805ad5;
+}
+[data-theme="light"] {
+  color-scheme: light;
 }
 [data-theme="light"] .launch-bar {
   background: color-mix(in srgb, var(--panel) 92%, transparent);

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -105,8 +105,12 @@ def main() -> int:
         page.get_by_role("button", name="Collapse workspace tree").click()
         if page.locator(".tree-row").filter(has_text=NOTE_TITLE).count() != 0:
             raise AssertionError("collapsed workspace tree still shows descendants")
-        page.get_by_role("button", name="Expand workspace tree").click()
+        nested_folder.click()
         page.locator(".tree-row").filter(has_text=NOTE_TITLE).first.wait_for()
+        if page.get_by_role("button", name="Collapse workspace tree").count() != 1:
+            raise AssertionError(
+                "clicking an expanded root did not reopen the globally collapsed tree"
+            )
 
         theme = page.locator(".app-shell").get_attribute("data-theme")
         dark_background = page.locator(".app-shell").evaluate(

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 from playwright.sync_api import Page, sync_playwright
@@ -149,16 +150,47 @@ def main() -> int:
         page.wait_for_url("**/p/Features.md")
 
         page.set_viewport_size({"width": 390, "height": 844})
-        for path in ("Index.md", "Usage.md", "Changelog.md", "Sandbox.md"):
-            title = path.removesuffix(".md")
-            page.locator(".tree-row").filter(has_text=title).last.click()
+        page.wait_for_timeout(200)
+        mobile_nav = page.locator(".mobile-nav-toggle")
+        mobile_nav.wait_for()
+        if mobile_nav.get_attribute("aria-label") != "Open workspace navigation":
+            raise AssertionError("mobile workspace navigation trigger is not labelled")
+        if mobile_nav.get_attribute("aria-expanded") != "false":
+            raise AssertionError("mobile workspace navigation is not closed by default")
+        sidebar = page.locator("#workspace-navigation")
+        sidebar_box = sidebar.bounding_box()
+        if sidebar_box and sidebar_box["x"] >= 0:
+            raise AssertionError("closed mobile workspace navigation remains on canvas")
+        for path, title in (
+            ("Index.md", "Miku Note"),
+            ("Usage.md", "Using Miku Note"),
+            ("Changelog.md", "Changelog"),
+            ("Sandbox.md", "Markdown Sandbox"),
+        ):
+            mobile_nav.click()
+            page.get_by_role("button", name="Close workspace navigation").last.wait_for()
+            if mobile_nav.get_attribute("aria-expanded") != "true":
+                raise AssertionError("mobile workspace navigation did not expose expanded state")
+            exact_label = page.locator(".tree-label", has_text=re.compile(f"^{re.escape(title)}$"))
+            page.locator(".tree-row").filter(has=exact_label).last.click()
             page.wait_for_url(f"**/p/{path}")
+            mobile_nav.wait_for()
+            if mobile_nav.get_attribute("aria-expanded") != "false":
+                raise AssertionError("mobile workspace navigation did not close after navigation")
             page.wait_for_timeout(250)
+        mobile_nav.click()
+        page.keyboard.press("Escape")
+        if mobile_nav.get_attribute("aria-expanded") != "false":
+            raise AssertionError("Escape did not close mobile workspace navigation")
+        if not mobile_nav.evaluate("element => element === document.activeElement"):
+            raise AssertionError("closing mobile workspace navigation did not restore focus")
         tabs = page.locator(".tabs")
         if tabs.evaluate("el => getComputedStyle(el).overflowX") not in ("auto", "scroll"):
             raise AssertionError("open tabs are not horizontally scrollable")
         if not tabs.evaluate("el => el.scrollWidth > el.clientWidth"):
             raise AssertionError("multiple open tabs did not overflow horizontally")
+        page.set_viewport_size({"width": 1440, "height": 900})
+        page.wait_for_timeout(200)
 
         page.goto(f"{BASE_URL}/p/does-not-exist.md", wait_until="domcontentloaded")
         page.wait_for_url(f"{BASE_URL}/p/Index.md", timeout=10_000)
@@ -184,7 +216,7 @@ def main() -> int:
         page.screenshot(path=str(ARTIFACT_DIR / "reading.png"), full_page=True)
         page.set_viewport_size({"width": 390, "height": 844})
         page.reload(wait_until="domcontentloaded")
-        page.get_by_text("All notes").wait_for()
+        page.locator(".mobile-nav-toggle").wait_for()
         if page.locator("body").evaluate("el => el.scrollWidth > el.clientWidth"):
             raise AssertionError("narrow viewport has horizontal overflow")
         page.screenshot(path=str(ARTIFACT_DIR / "narrow.png"), full_page=True)

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -114,12 +114,18 @@ def main() -> int:
             )
 
         theme = page.locator(".app-shell").get_attribute("data-theme")
+        favicon = page.locator("#miku-favicon")
+        if not favicon.get_attribute("href").endswith(f"/miku-icon-{theme}.svg"):
+            raise AssertionError("favicon does not match the active shell theme")
         dark_background = page.locator(".app-shell").evaluate(
             "el => getComputedStyle(el).backgroundColor"
         )
         page.get_by_role("button", name="Toggle theme").click()
-        if page.locator(".app-shell").get_attribute("data-theme") == theme:
+        toggled_theme = page.locator(".app-shell").get_attribute("data-theme")
+        if toggled_theme == theme:
             raise AssertionError("theme toggle did not change the shell theme")
+        if not favicon.get_attribute("href").endswith(f"/miku-icon-{toggled_theme}.svg"):
+            raise AssertionError("favicon did not follow the shell theme toggle")
         light_background = page.locator(".app-shell").evaluate(
             "el => getComputedStyle(el).backgroundColor"
         )


### PR DESCRIPTION
## Summary
- restore one-click lazy tree expansion and apply folder parents consistently
- reduce folder tree reads to one representative row per immediate child
- ignore Markdown links inside inline and fenced code
- add an accessible mobile navigation drawer and low-contrast dark scrollbars

## Verification
- `make check`
- `uv run python scripts/ux_browser.py`
- folder tree endpoint benchmark: 31.2 ms mean across 15 local runs