### PR TITLE
fix(ux): refine workspace navigation and prepare 0.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,4 @@ All daily operations go through the Makefile. Python automation runs through uv 
 
 Run make check before committing and make validate before opening a PR. Use conventional commits and stage files explicitly. Never commit local indexes, runtime artifacts, screenshots, or secrets.
 
-See miku_docs/architecture.md, miku_docs/Features.md, and miku_docs/adr/ for the current product and architecture contracts.
+See miku_docs/architecture.md, miku_docs/features.md, and miku_docs/adr/ for the current product and architecture contracts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,7 +1101,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miku"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "miku-app"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "miku-cache-valkey",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "miku-cache-valkey"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "redis",
  "serde",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "miku-domain"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "miku-index-memory"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "miku-domain",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "miku-index-postgres"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "miku-domain",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "miku-index-sqlite"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "miku-indexer"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "aho-corasick",
  "miku-domain",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "miku-markdown"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "comrak",
  "lazy_static",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "miku-vault"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "miku-domain",
  "miku-markdown",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev fmt fmt-check css lint test check check-all-features check-integration experiments compose-experiments \
+.PHONY: dev fmt fmt-check css lint test kb-check check check-all-features check-integration experiments compose-experiments \
   check-blackbox check-ux-smoke check-ux-soak check-ux-browser benchmark \
   benchmark-real-vault release validate
 
@@ -21,7 +21,10 @@ lint:
 test:
 	uv run python scripts/orchestrate.py test
 
-check:
+kb-check:
+	uv run scripts/check_kb_conventions.py
+
+check: kb-check
 	uv run python scripts/orchestrate.py check
 
 check-all-features:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Before opening a pull request, run `make check`. Keep user content, local indexe
 
 ## Project status
 
-Miku Note is an early, actively evolving project. The current milestone is `v0.0.3`; the user-facing changelog is [`miku_docs/Changelog.md`](miku_docs/Changelog.md). APIs, templates, and configuration
+Miku Note is an early, actively evolving project. The current milestone is `v0.0.5`; the user-facing changelog is [`miku_docs/changelog.md`](miku_docs/changelog.md). APIs, templates, and configuration
 may change while the core filesystem-first invariant remains stable.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ This makes the vault easy to inspect, back up, version, or edit with another too
 | Knowledge graph | Backlinks, linked mentions, tags, and paginated tag views                                                  |
 | Search          | Metadata quick-switch plus embedded full-text content search powered by Rust's grep/ignore crates          |
 | Editing         | Browser editor, inline reader editing, preview, atomic writes, and conflict-aware saves                    |
-| Runtime         | MemoryIndex/Tantivy hot projection by default; optional SQLite/Postgres durability and Valkey shared cache |
+| Runtime         | SQLite search and durable metadata by default; MemoryIndex graph; optional Postgres and Valkey profiles    |
 | UX              | Light/dark themes, reading-width modes, lazy editor/highlighter loading, and a focused command palette     |
 
 ## Quick start
 
-The default development path uses SQLite as the durable projection and MemoryIndex/Tantivy as the hot projection. PostgreSQL and Valkey are optional infrastructure layers; Valkey is a shared cache,
-not a replacement for Tantivy.
+The default development path uses SQLite for durable metadata and full-text search, with MemoryIndex as a rebuildable in-process graph projection. PostgreSQL and Valkey are optional infrastructure
+layers. Tantivy is no longer part of the runtime.
 
 ```bash
 git clone https://github.com/azusachino/miku.git

--- a/crates/miku-app/Cargo.toml
+++ b/crates/miku-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-app"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -8,13 +8,13 @@ description = "Backend-neutral application index API for Miku"
 
 [dependencies]
 async-trait.workspace = true
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-indexer = { version = "0.0.4", path = "../miku-indexer" }
-miku-vault = { version = "0.0.4", path = "../miku-vault" }
-miku-index-memory = { version = "0.0.4", path = "../miku-index-memory", optional = true }
-miku-index-postgres = { version = "0.0.4", path = "../miku-index-postgres", optional = true }
-miku-index-sqlite = { version = "0.0.4", path = "../miku-index-sqlite", optional = true }
-miku-cache-valkey = { version = "0.0.4", path = "../miku-cache-valkey", optional = true }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-indexer = { version = "0.0.5", path = "../miku-indexer" }
+miku-vault = { version = "0.0.5", path = "../miku-vault" }
+miku-index-memory = { version = "0.0.5", path = "../miku-index-memory", optional = true }
+miku-index-postgres = { version = "0.0.5", path = "../miku-index-postgres", optional = true }
+miku-index-sqlite = { version = "0.0.5", path = "../miku-index-sqlite", optional = true }
+miku-cache-valkey = { version = "0.0.5", path = "../miku-cache-valkey", optional = true }
 sqlx = { version = "0.8.6", optional = true, features = ["postgres", "runtime-tokio-rustls"] }
 serde.workspace = true
 serde_json.workspace = true
@@ -29,6 +29,6 @@ postgres = ["dep:miku-index-postgres", "dep:sqlx"]
 valkey = ["dep:miku-cache-valkey"]
 
 [dev-dependencies]
-miku-index-memory = { version = "0.0.4", path = "../miku-index-memory" }
+miku-index-memory = { version = "0.0.5", path = "../miku-index-memory" }
 tempfile = "3"
 tokio.workspace = true

--- a/crates/miku-app/src/application.rs
+++ b/crates/miku-app/src/application.rs
@@ -340,7 +340,7 @@ impl VaultReader for FileMikuApplication {
         };
         let pages = self
             .index
-            .list_pages_under(&prefix)
+            .list_tree_pages(&prefix)
             .await
             .map_err(ApplicationError::from)?;
         Ok(FileTree {

--- a/crates/miku-app/src/lib.rs
+++ b/crates/miku-app/src/lib.rs
@@ -179,6 +179,11 @@ impl IndexApi {
         self.reader.list_pages_under(prefix).await
     }
 
+    /// Return the minimal projection required for one lazy tree level.
+    pub async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        self.reader.list_tree_pages(prefix).await
+    }
+
     /// Load one page summary.
     pub async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>> {
         self.reader.page(path).await

--- a/crates/miku-cache-valkey/Cargo.toml
+++ b/crates/miku-cache-valkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-cache-valkey"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/miku-domain/Cargo.toml
+++ b/crates/miku-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-domain"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/miku-domain/src/lib.rs
+++ b/crates/miku-domain/src/lib.rs
@@ -268,6 +268,13 @@ pub trait IndexReader: Send + Sync {
         })
     }
 
+    /// Return only the indexed rows needed to build one lazy tree level:
+    /// direct Markdown files plus one representative descendant per child
+    /// folder. Backends may override this to avoid loading every descendant.
+    async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        self.list_pages_under(prefix).await
+    }
+
     /// Load one indexed page summary, if it exists.
     async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>>;
 

--- a/crates/miku-index-memory/Cargo.toml
+++ b/crates/miku-index-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-index-memory"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -8,9 +8,9 @@ description = "In-memory reference IndexStore for Miku"
 
 [dependencies]
 async-trait.workspace = true
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-indexer = { version = "0.0.4", path = "../miku-indexer" }
-miku-markdown = { version = "0.0.4", path = "../miku-markdown" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-indexer = { version = "0.0.5", path = "../miku-indexer" }
+miku-markdown = { version = "0.0.5", path = "../miku-markdown" }
 
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/miku-index-postgres/Cargo.toml
+++ b/crates/miku-index-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-index-postgres"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -8,7 +8,7 @@ description = "Postgres IndexStore implementation for Miku"
 
 [dependencies]
 async-trait.workspace = true
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-indexer = { version = "0.0.4", path = "../miku-indexer" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-indexer = { version = "0.0.5", path = "../miku-indexer" }
 serde_json.workspace = true
 sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio-rustls"] }

--- a/crates/miku-index-sqlite/Cargo.toml
+++ b/crates/miku-index-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-index-sqlite"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -9,7 +9,7 @@ description = "SQLite IndexStore implementation for Miku"
 [dependencies]
 async-trait.workspace = true
 futures-util = "0.3"
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
 rayon = "1"
 serde_json.workspace = true
 sqlx = { version = "0.8.6", default-features = false, features = ["sqlite", "runtime-tokio", "migrate", "macros"] }

--- a/crates/miku-index-sqlite/src/lib.rs
+++ b/crates/miku-index-sqlite/src/lib.rs
@@ -184,6 +184,61 @@ impl IndexReader for SqliteIndex {
         Ok(summaries)
     }
 
+    async fn list_tree_pages(&self, prefix: &str) -> StoreResult<Vec<PageSummary>> {
+        let escaped_prefix = prefix
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let rows = sqlx::query_as::<_, (String, String, String, i64)>(
+            "WITH scoped AS (
+                 SELECT path,
+                        CASE
+                            WHEN instr(substr(path, length(?) + 1), '/') = 0
+                                THEN substr(path, length(?) + 1)
+                            ELSE substr(
+                                substr(path, length(?) + 1),
+                                1,
+                                instr(substr(path, length(?) + 1), '/') - 1
+                            )
+                        END AS child
+                 FROM tb_pages
+                 WHERE path LIKE ? ESCAPE '\\'
+             ),
+             selected AS (
+                 SELECT min(path) AS path
+                 FROM scoped
+                 GROUP BY child
+             )
+             SELECT page.path, page.title, page.frontmatter, page.mtime
+             FROM tb_pages AS page
+             JOIN selected ON selected.path = page.path
+             ORDER BY page.title, page.path",
+        )
+        .bind(prefix)
+        .bind(prefix)
+        .bind(prefix)
+        .bind(prefix)
+        .bind(format!("{escaped_prefix}%"))
+        .fetch_all(self.pool())
+        .await
+        .map_err(database_error)?;
+
+        let mut summaries = Vec::with_capacity(rows.len());
+        for (path, title, frontmatter_str, mtime) in rows {
+            let frontmatter: serde_json::Value = serde_json::from_str(&frontmatter_str)
+                .map_err(|e| StoreError::Operation(format!("invalid frontmatter JSON: {e}")))?;
+            let aliases = frontmatter_aliases(&frontmatter);
+            summaries.push(PageSummary {
+                path,
+                title,
+                frontmatter,
+                mtime,
+                aliases,
+            });
+        }
+        Ok(summaries)
+    }
+
     async fn page(&self, path: &str) -> StoreResult<Option<PageSummary>> {
         let row = sqlx::query_as::<_, (String, String, String, i64)>(
             "SELECT path, title, frontmatter, mtime FROM tb_pages WHERE path = ?",
@@ -836,6 +891,7 @@ mod tests {
             .replace_pages(vec![
                 test_page("folder/One.md", "one", vec![], vec![]),
                 test_page("folder/nested/Two.md", "two", vec![], vec![]),
+                test_page("folder/nested/Three.md", "three nested", vec![], vec![]),
                 test_page("other/Three.md", "three", vec![], vec![]),
                 test_page("folder-sibling/Four.md", "four", vec![], vec![]),
             ])
@@ -848,13 +904,42 @@ mod tests {
             .expect("list pages under folder/");
         let mut scoped_paths: Vec<_> = scoped.iter().map(|page| page.path.clone()).collect();
         scoped_paths.sort();
-        assert_eq!(scoped_paths, vec!["folder/One.md", "folder/nested/Two.md"]);
+        assert_eq!(
+            scoped_paths,
+            vec![
+                "folder/One.md",
+                "folder/nested/Three.md",
+                "folder/nested/Two.md"
+            ]
+        );
+
+        let tree_pages = store
+            .list_tree_pages("folder/")
+            .await
+            .expect("list one folder tree level");
+        assert_eq!(tree_pages.len(), 2);
+        assert!(tree_pages.iter().any(|page| page.path == "folder/One.md"));
+        assert_eq!(
+            tree_pages
+                .iter()
+                .filter(|page| page.path.starts_with("folder/nested/"))
+                .count(),
+            1
+        );
 
         let all = store
             .list_pages_under("")
             .await
             .expect("empty prefix lists everything");
-        assert_eq!(all.len(), 4);
+        assert_eq!(all.len(), 5);
+        assert_eq!(
+            store
+                .list_tree_pages("")
+                .await
+                .expect("list root tree level")
+                .len(),
+            3
+        );
 
         let none = store
             .list_pages_under("nonexistent/")

--- a/crates/miku-indexer/Cargo.toml
+++ b/crates/miku-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-indexer"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -8,8 +8,8 @@ description = "Filesystem-to-index projection builder for Miku"
 
 [dependencies]
 aho-corasick.workspace = true
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-markdown = { version = "0.0.4", path = "../miku-markdown" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-markdown = { version = "0.0.5", path = "../miku-markdown" }
 regex.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/miku-indexer/src/lib.rs
+++ b/crates/miku-indexer/src/lib.rs
@@ -28,6 +28,10 @@ static EXTERNAL_LINK_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::ne
     Regex::new(r"^[a-zA-Z][a-zA-Z\d+.-]*:").expect("external link regex")
 });
 
+static CODE_RANGE_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new(r"(?s)```.*?```|~~~.*?~~~|`[^`\n]*`").expect("code range regex")
+});
+
 /// Mirrors the frontend's `/^[a-z][a-z\d+.-]*:/i` scheme-prefix check
 /// (`noteLinks.ts`) so external URLs (`https:`, `mailto:`, ...) are never
 /// treated as page/asset targets.
@@ -48,9 +52,19 @@ pub fn build_page_index(path: &str, raw: &[u8], mtime: i64) -> PageIndex {
             text: heading.text,
         })
         .collect();
+    let code_ranges = CODE_RANGE_REGEX
+        .find_iter(body)
+        .map(|matched| matched.start()..matched.end())
+        .collect::<Vec<_>>();
 
     let mut links: Vec<LinkRecord> = WIKILINK_REGEX
         .captures_iter(body)
+        .filter(|capture| {
+            let matched = capture.get(0).expect("wikilink capture has a full match");
+            !code_ranges
+                .iter()
+                .any(|range| range.start <= matched.start() && matched.end() <= range.end)
+        })
         .map(|capture| {
             let target = capture[2].trim().to_string();
             let is_embed = !capture[1].is_empty();
@@ -73,6 +87,14 @@ pub fn build_page_index(path: &str, raw: &[u8], mtime: i64) -> PageIndex {
     links.extend(
         MARKDOWN_LINK_REGEX
             .captures_iter(body)
+            .filter(|capture| {
+                let matched = capture
+                    .get(0)
+                    .expect("markdown link capture has a full match");
+                !code_ranges
+                    .iter()
+                    .any(|range| range.start <= matched.start() && matched.end() <= range.end)
+            })
             .filter_map(|capture| {
                 let target = capture[3].trim().to_string();
                 if target.is_empty() || target.starts_with('#') || is_external_link(&target) {
@@ -228,6 +250,19 @@ mod tests {
             .unwrap();
         assert!(embed.is_embed);
         assert_eq!(embed.kind, LinkKind::Asset);
+    }
+
+    #[test]
+    fn skips_links_inside_fenced_and_inline_code() {
+        let page = build_page_index(
+            "Code.md",
+            b"```markdown\n[wikilinks](/p/wikilinks.md)\n[[fenced-wikilink]]\n```\n~~~md\n[tilde](/p/tilde.md)\n~~~\n`[inline](/p/inline.md)`\n[Visible](/p/visible.md)",
+            1,
+        );
+
+        assert_eq!(page.links.len(), 1);
+        assert_eq!(page.links[0].target, "/p/visible.md");
+        assert_eq!(page.links[0].alias.as_deref(), Some("Visible"));
     }
 
     #[test]

--- a/crates/miku-markdown/Cargo.toml
+++ b/crates/miku-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku-markdown"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/miku-vault/Cargo.toml
+++ b/crates/miku-vault/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "miku-vault"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atomic file-backed Markdown vault operations for Miku"
 
 [dependencies]
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-markdown = { version = "0.0.4", path = "../miku-markdown" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-markdown = { version = "0.0.5", path = "../miku-markdown" }
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/miku/Cargo.toml
+++ b/crates/miku/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miku"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["azusachino <azusachino@duck.com>"]
 edition.workspace = true
 description = "A filesystem-owned personal Markdown wiki with browser editing and background indexing for backlinks, tags, and full-text search."
@@ -13,10 +13,10 @@ include = ["src/**/*", "../../README.md", "../../LICENSE"]
 
 [dependencies]
 anyhow.workspace = true
-miku-domain = { version = "0.0.4", path = "../miku-domain" }
-miku-app = { version = "0.0.4", path = "../miku-app", default-features = false }
-miku-indexer = { version = "0.0.4", path = "../miku-indexer" }
-miku-vault = { version = "0.0.4", path = "../miku-vault" }
+miku-domain = { version = "0.0.5", path = "../miku-domain" }
+miku-app = { version = "0.0.5", path = "../miku-app", default-features = false }
+miku-indexer = { version = "0.0.5", path = "../miku-indexer" }
+miku-vault = { version = "0.0.5", path = "../miku-vault" }
 axum.workspace = true
 chrono.workspace = true
 notify.workspace = true
@@ -39,8 +39,8 @@ valkey = ["miku-app/valkey"]
 postgres-valkey = ["postgres", "valkey"]
 
 [dev-dependencies]
-miku-index-memory = { version = "0.0.4", path = "../miku-index-memory" }
-miku-index-sqlite = { version = "0.0.4", path = "../miku-index-sqlite" }
+miku-index-memory = { version = "0.0.5", path = "../miku-index-memory" }
+miku-index-sqlite = { version = "0.0.5", path = "../miku-index-sqlite" }
 
 [lints]
 workspace = true

--- a/crates/miku/src/http_api.rs
+++ b/crates/miku/src/http_api.rs
@@ -13,7 +13,7 @@ use miku_domain::{workspace::NoteId, Backlink, SearchRequest, SearchScope};
 
 use miku_vault::VaultDocument;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::{AppError, AppState};
 
@@ -177,6 +177,21 @@ pub struct SearchResponse {
 pub struct TagResponse {
     pub tag: String,
     pub count: i64,
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct TagQuery {
+    /// Maximum tags returned per page (default 50, maximum 200).
+    limit: Option<usize>,
+    /// Number of sorted tags to skip.
+    offset: Option<usize>,
+}
+
+fn tag_page(query: &TagQuery) -> (usize, usize) {
+    (
+        query.offset.unwrap_or(0),
+        query.limit.unwrap_or(50).clamp(1, 200),
+    )
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -378,11 +393,17 @@ pub async fn search(
     }))
 }
 
-#[utoipa::path(get, path = "/api/v1/tags", responses((status = 200, body = [TagResponse])))]
-pub async fn tags(State(state): State<AppState>) -> Result<Json<Vec<TagResponse>>, AppError> {
+#[utoipa::path(get, path = "/api/v1/tags", params(TagQuery), responses((status = 200, body = [TagResponse])))]
+pub async fn tags(
+    Query(query): Query<TagQuery>,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<TagResponse>>, AppError> {
     let tags = state.application.tags().await.map_err(application_error)?;
+    let (offset, limit) = tag_page(&query);
     Ok(Json(
         tags.into_iter()
+            .skip(offset)
+            .take(limit)
             .map(|tag| TagResponse {
                 tag: tag.tag,
                 count: tag.count,
@@ -666,5 +687,23 @@ mod tests {
             Some("geektime-docs/AI-\u{5927}\u{6570}\u{636e}".to_string())
         );
         assert_eq!(tree_parent_id(&RelativePath::root(), None), None);
+    }
+
+    #[test]
+    fn tag_pages_default_and_cap_the_response_window() {
+        assert_eq!(
+            tag_page(&TagQuery {
+                limit: None,
+                offset: None
+            }),
+            (0, 50)
+        );
+        assert_eq!(
+            tag_page(&TagQuery {
+                limit: Some(10_000),
+                offset: Some(75)
+            }),
+            (75, 200)
+        );
     }
 }

--- a/crates/miku/src/http_api.rs
+++ b/crates/miku/src/http_api.rs
@@ -229,9 +229,14 @@ pub async fn tree(
         .file_tree(FileTreeRequest { folder })
         .await
         .map_err(application_error)?;
+    let parent_id = tree_parent_id(&tree.folder, query.parent_id.clone());
     Ok(Json(TreeResponse {
-        parent_id: query.parent_id.clone(),
-        nodes: tree.nodes.into_iter().map(tree_node).collect(),
+        parent_id: parent_id.clone(),
+        nodes: tree
+            .nodes
+            .into_iter()
+            .map(|node| tree_node_with_parent(node, parent_id.clone()))
+            .collect(),
     }))
 }
 
@@ -434,15 +439,18 @@ fn application_error(error: ApplicationError) -> AppError {
     }
 }
 
-fn tree_node(node: FileNode) -> TreeNode {
-    tree_node_with_parent(node, None)
+fn tree_parent_id(folder: &RelativePath, compatibility_parent: Option<String>) -> Option<String> {
+    if folder.as_str().is_empty() {
+        compatibility_parent
+    } else {
+        Some(folder.as_str().to_string())
+    }
 }
 
 /// Builds a `TreeNode`, tagging it with `parent_id` when the caller knows
 /// it (e.g. mapping a note's `children` to entries parented by that note --
 /// `FileNode` itself carries no parent reference, so this can't be derived
-/// from `node` alone). `/api/v1/tree`'s root/folder-scoped nodes have no
-/// such relationship yet and keep using `tree_node` (`parent_id`: None).
+/// from `node` alone).
 fn tree_node_with_parent(node: FileNode, parent_id: Option<String>) -> TreeNode {
     let note_id = node
         .note_id
@@ -634,10 +642,11 @@ mod tests {
     }
 
     #[test]
-    fn tree_node_has_no_parent_by_default() {
-        // /api/v1/tree's root/folder-scoped nodes have no known parent
-        // note relationship yet.
-        assert_eq!(tree_node(file_node("Notes/N1.md")).parent_id, None);
+    fn root_tree_node_has_no_parent() {
+        assert_eq!(
+            tree_node_with_parent(file_node("Notes/N1.md"), None).parent_id,
+            None
+        );
     }
 
     #[test]
@@ -647,5 +656,15 @@ mod tests {
         // None in every response regardless of the actual relationship.
         let node = tree_node_with_parent(file_node("Notes/Child.md"), Some("parent-1".to_string()));
         assert_eq!(node.parent_id, Some("parent-1".to_string()));
+    }
+
+    #[test]
+    fn folder_scoped_tree_applies_parent_to_the_response_and_every_child() {
+        let folder = RelativePath::new("geektime-docs/AI-\u{5927}\u{6570}\u{636e}").unwrap();
+        assert_eq!(
+            tree_parent_id(&folder, None),
+            Some("geektime-docs/AI-\u{5927}\u{6570}\u{636e}".to_string())
+        );
+        assert_eq!(tree_parent_id(&RelativePath::root(), None), None);
     }
 }

--- a/crates/miku/src/indexer.rs
+++ b/crates/miku/src/indexer.rs
@@ -708,7 +708,7 @@ mod tests {
 
     /// Coarse process RSS via `ps`, used only to report an order-of-magnitude
     /// memory delta for the opt-in real-vault benchmark. Includes allocator
-    /// and Tokio/Tantivy overhead, not just the page-graph structures.
+    /// and Tokio overhead, not just the page-graph structures.
     fn current_rss_kb() -> u32 {
         let pid = std::process::id().to_string();
         let output = std::process::Command::new("ps")

--- a/crates/miku/src/lib.rs
+++ b/crates/miku/src/lib.rs
@@ -317,7 +317,7 @@ pub(crate) async fn metrics(State(state): State<AppState>) -> impl IntoResponse 
         [
             (
                 axum::http::header::CONTENT_TYPE,
-                "text/plain; version=0.0.4",
+                "text/plain; version=0.0.5",
             ),
             (SERVER_TIMING, ""),
         ],

--- a/crates/miku/src/openapi.rs
+++ b/crates/miku/src/openapi.rs
@@ -9,7 +9,7 @@ use crate::http_api;
 #[openapi(
     info(
         title = "Miku Workspace API",
-        version = "0.0.4",
+        version = "0.0.5",
         description = "Read-only workspace contract for the file-backed Markdown UI"
     ),
     paths(

--- a/miku-web/index.html
+++ b/miku-web/index.html
@@ -7,7 +7,7 @@
     <meta name="application-name" content="Miku Note" />
     <link id="miku-favicon" rel="icon" type="image/svg+xml" href="/miku-icon-light.svg" />
     <title>Miku Note</title>
-    <script>document.getElementById('miku-favicon').href = matchMedia('(prefers-color-scheme: dark)').matches ? '/miku-icon-dark.svg' : '/miku-icon-light.svg';</script>
+    <script>document.getElementById('miku-favicon').href = (localStorage.getItem('miku:ui:v2') || localStorage.getItem('miku-theme')) === 'light' ? '/miku-icon-light.svg' : '/miku-icon-dark.svg';</script>
   </head>
   <body>
     <div id="root"></div>

--- a/miku-web/package.json
+++ b/miku-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "miku-web",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/miku-web/src/components/workspace/WorkspaceTree.test.tsx
+++ b/miku-web/src/components/workspace/WorkspaceTree.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TreeNodeModel } from "../../features/workspace/api";
+import { EXPLORER_STATE_KEY } from "../../shared/ui";
+import { WorkspaceTree } from "./WorkspaceTree";
+
+function folder(path: string): TreeNodeModel {
+  return {
+    kind: "folder",
+    path,
+    hasChildren: true,
+    placementId: `path:${path}`,
+    noteId: path,
+    parentId: null,
+    note: {
+      id: path,
+      path,
+      title: path.split("/").at(-1) ?? path,
+      identityGenerated: false,
+      parents: [],
+      aliases: []
+    }
+  };
+}
+
+function markdown(path: string): TreeNodeModel {
+  return {
+    ...folder(path),
+    kind: "markdown",
+    hasChildren: false
+  };
+}
+
+describe("WorkspaceTree", () => {
+  it("reopens a globally collapsed tree when a folder is clicked once", async () => {
+    const tree = vi.fn().mockResolvedValue([folder("dedao-docs/docs"), markdown("dedao-docs/README.md")]);
+    const rootNodes = [folder("dedao-docs")];
+    localStorage.setItem(EXPLORER_STATE_KEY, JSON.stringify(["dedao-docs"]));
+
+    function CollapsedTree() {
+      const [hoisted, setHoisted] = useState(true);
+      return <WorkspaceTree notes={[]} nodes={rootNodes} activeId="" onSelect={() => undefined} hoisted={hoisted} onExpandTree={() => setHoisted(false)} client={{ tree } as never} />;
+    }
+
+    render(<CollapsedTree />);
+    fireEvent.click(screen.getByRole("button", { name: "dedao-docs" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "docs" })).toBeTruthy());
+    expect(screen.getByRole("button", { name: "README.md" })).toBeTruthy();
+    expect(tree).toHaveBeenCalledWith("dedao-docs");
+    localStorage.clear();
+  });
+});

--- a/miku-web/src/components/workspace/WorkspaceTree.tsx
+++ b/miku-web/src/components/workspace/WorkspaceTree.tsx
@@ -9,6 +9,7 @@ export function WorkspaceTree({
   activeId,
   onSelect,
   hoisted,
+  onExpandTree,
   client
 }: {
   notes: NoteModel[];
@@ -16,6 +17,7 @@ export function WorkspaceTree({
   activeId: string;
   onSelect: (id: string) => void;
   hoisted: boolean;
+  onExpandTree: () => void;
   client: ReturnType<typeof createWorkspaceClient>;
 }) {
   const noteMap = useMemo(() => new Map(notes.map((note) => [note.id, note])), [notes]);
@@ -24,7 +26,7 @@ export function WorkspaceTree({
     return new Set(persisted.filter((path) => !persisted.some((parent) => parent !== path && path.startsWith(`${parent}/`))));
   });
   const [loaded, setLoaded] = useState<Record<string, TreeNodeModel[]>>({});
-  const roots = sortTreeNodes(nodes.filter((node) => node.parentId === null));
+  const roots = useMemo(() => sortTreeNodes(nodes.filter((node) => node.parentId === null)), [nodes]);
 
   useEffect(() => {
     if (!activeId || hoisted) return;
@@ -69,6 +71,10 @@ export function WorkspaceTree({
     const indexNote = children.find((child) => child.kind === "markdown" && child.path === `${node.path}/index.md`);
     const title = isFolder ? (indexNote?.note.title ?? node.note.title) : note.title;
     const toggleFolder = async () => {
+      if (hoisted) {
+        onExpandTree();
+        if (isExpanded) return;
+      }
       if (isExpanded) {
         setExpanded((current) => new Set([...current].filter((path) => path !== node.path)));
         return;

--- a/miku-web/src/components/workspace/WorkspaceTree.tsx
+++ b/miku-web/src/components/workspace/WorkspaceTree.tsx
@@ -64,7 +64,7 @@ export function WorkspaceTree({
   }, [client, expanded, loaded, roots]);
 
   const branch = (node: TreeNodeModel, depth: number) => {
-    const note = noteMap.get(node.noteId) ?? { ...node.note, icon: "file-text", updated: "unknown", body: "", backlinks: [], tags: [] };
+    const note = noteMap.get(node.noteId) ?? { ...node.note, icon: "file-text", frontmatter: {}, updated: "unknown", body: "", backlinks: [], tags: [] };
     const children = sortTreeNodes(loaded[node.path] ?? []);
     const isFolder = node.kind === "folder";
     const isExpanded = expanded.has(node.path);

--- a/miku-web/src/components/workspace/icons.tsx
+++ b/miku-web/src/components/workspace/icons.tsx
@@ -10,6 +10,7 @@ import { FileText } from "@phosphor-icons/react/dist/icons/FileText";
 import { Folder } from "@phosphor-icons/react/dist/icons/Folder";
 import { GearSix } from "@phosphor-icons/react/dist/icons/GearSix";
 import { Hash } from "@phosphor-icons/react/dist/icons/Hash";
+import { List } from "@phosphor-icons/react/dist/icons/List";
 import { MagnifyingGlass } from "@phosphor-icons/react/dist/icons/MagnifyingGlass";
 import { Moon } from "@phosphor-icons/react/dist/icons/Moon";
 import { Rocket } from "@phosphor-icons/react/dist/icons/Rocket";
@@ -18,7 +19,7 @@ import { TreeStructure } from "@phosphor-icons/react/dist/icons/TreeStructure";
 import { X } from "@phosphor-icons/react/dist/icons/X";
 import type { Icon } from "@phosphor-icons/react";
 
-export type ActionIconName = "arrow-up" | "arrow-up-right" | "chevron-down" | "chevron-left" | "chevron-right" | "close" | "hash" | "moon" | "search" | "settings" | "sun" | "tree" | "clock";
+export type ActionIconName = "arrow-up" | "arrow-up-right" | "chevron-down" | "chevron-left" | "chevron-right" | "close" | "hash" | "menu" | "moon" | "search" | "settings" | "sun" | "tree" | "clock";
 
 export function ActionIcon({ name }: { name: ActionIconName }) {
   const icons: Record<ActionIconName, Icon> = {
@@ -29,6 +30,7 @@ export function ActionIcon({ name }: { name: ActionIconName }) {
     "chevron-right": CaretRight,
     close: X,
     hash: Hash,
+    menu: List,
     moon: Moon,
     search: MagnifyingGlass,
     settings: GearSix,

--- a/miku-web/src/features/markdown/noteLinks.test.ts
+++ b/miku-web/src/features/markdown/noteLinks.test.ts
@@ -81,5 +81,12 @@ describe("extractOutgoingLinks", () => {
       { path: "vault/maps/uncreated-note.md", title: "uncreated-note", isMissing: true }
     ]);
   });
-});
 
+  it("ignores links inside fenced and inline code", () => {
+    const body = ["```markdown", "[wikilinks](/p/wikilinks.md)", "[[fenced-wikilink]]", "```", "~~~md", "[tilde](/p/tilde.md)", "~~~", "`[inline](/p/inline.md)`", "[visible](/p/visible.md)"].join(
+      "\n"
+    );
+
+    expect(extractOutgoingLinks(body)).toEqual([{ path: "visible.md", title: "visible", isMissing: true }]);
+  });
+});

--- a/miku-web/src/features/markdown/noteLinks.ts
+++ b/miku-web/src/features/markdown/noteLinks.ts
@@ -1,6 +1,10 @@
 export type NoteCandidate = { id?: string; path: string; title?: string; aliases?: string[] };
 export type TargetResolver = (target: string) => string | null;
 
+function proseSegments(markdown: string): string[] {
+  return markdown.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`)/g).filter((_, index) => index % 2 === 0);
+}
+
 export function isAssetFile(path: string): boolean {
   const lower = path.trim().toLowerCase();
   return (
@@ -171,17 +175,17 @@ export function extractOutgoingLinks(body: string, notes?: NoteCandidate[], curr
     results.push({ path: finalPath, title, isMissing });
   };
 
+  for (const segment of proseSegments(body)) {
+    // 1. [[wikilink|label]]
+    for (const match of segment.matchAll(/(?<!!)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g)) {
+      addLink(match[1], match[2]);
+    }
 
-  // 1. [[wikilink|label]]
-  for (const match of body.matchAll(/(?<!!)\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g)) {
-    addLink(match[1], match[2]);
-  }
-
-  // 2. [label](/p/target) or [label](target.md)
-  for (const match of body.matchAll(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/g)) {
-    addLink(match[2], match[1]);
+    // 2. [label](/p/target) or [label](target.md)
+    for (const match of segment.matchAll(/(?<!!)\[([^\]]+)\]\(([^)]+)\)/g)) {
+      addLink(match[2], match[1]);
+    }
   }
 
   return results;
 }
-

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -253,6 +253,8 @@ export function WorkspaceScreen() {
     dispatch({ type: "open", id: targetId });
     navigate(`/p/${targetId.split("/").map(encodeURIComponent).join("/")}`);
     setSearchOpen(false);
+    setQuery("");
+    setSearchSelection(-1);
     const recent = JSON.parse(localStorage.getItem("miku-recent") ?? "[]") as string[];
     localStorage.setItem("miku-recent", JSON.stringify([targetId, ...recent.filter((path) => path !== targetId)].slice(0, 20)));
   };

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -26,6 +26,7 @@ export function WorkspaceScreen() {
   const [theme, setTheme] = useState<Theme>(readTheme);
   const searchPanelRef = useRef<HTMLDivElement>(null);
   const mobileNavButtonRef = useRef<HTMLButtonElement>(null);
+  const closingTabRef = useRef<string | null>(null);
   const resizingSidebar = useRef(false);
   const resizingContext = useRef(false);
   const navigate = useNavigate();
@@ -140,6 +141,7 @@ export function WorkspaceScreen() {
     isError: context.isError,
     hasNote: Boolean(context.data?.note),
     canonicalId: contextualNote && !context.isPlaceholderData ? normalizeNotePath(contextualNote.path) : undefined,
+    closingIdRef: closingTabRef,
     tabs: state.tabs,
     dispatch,
     navigate,
@@ -254,7 +256,12 @@ export function WorkspaceScreen() {
     const recent = JSON.parse(localStorage.getItem("miku-recent") ?? "[]") as string[];
     localStorage.setItem("miku-recent", JSON.stringify([targetId, ...recent.filter((path) => path !== targetId)].slice(0, 20)));
   };
-  const closeTabHandler = (id: string) => closeTab({ id, tabs: state.tabs, activeId, dispatch, navigate });
+  const closeTabHandler = (id: string) => {
+    if (normalizeNotePath(id) === normalizeNotePath(activeId)) {
+      closingTabRef.current = normalizeNotePath(id);
+    }
+    closeTab({ id, tabs: state.tabs, activeId, dispatch, navigate });
+  };
   const openBreadcrumbPath = (path: string) => {
     if (!path) {
       navigate("/");

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -17,6 +17,7 @@ export function WorkspaceScreen() {
   const [searchScope, setSearchScope] = useState<SearchScope>("all");
   const [searchSelection, setSearchSelection] = useState(-1);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => Number(localStorage.getItem("miku-sidebar-width") ?? 244));
   const [contextWidth, setContextWidth] = useState(() => Number(localStorage.getItem("miku-context-width") ?? 235));
   const [notice, setNotice] = useState<string | null>(null);
@@ -24,6 +25,7 @@ export function WorkspaceScreen() {
   const [apiSource, setApiSource] = useState<ApiSource>("connecting");
   const [theme, setTheme] = useState<Theme>(readTheme);
   const searchPanelRef = useRef<HTMLDivElement>(null);
+  const mobileNavButtonRef = useRef<HTMLButtonElement>(null);
   const resizingSidebar = useRef(false);
   const resizingContext = useRef(false);
   const navigate = useNavigate();
@@ -206,6 +208,19 @@ export function WorkspaceScreen() {
   useEffect(() => {
     localStorage.setItem("miku-context-width", String(contextWidth));
   }, [contextWidth]);
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setMobileNavOpen(false);
+      mobileNavButtonRef.current?.focus();
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [mobileNavOpen]);
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => {
     if (!searchOpen) return;
@@ -286,7 +301,14 @@ export function WorkspaceScreen() {
   const secondaryNote = notes.find((candidate) => candidate.id === (state.tabs.find((tab) => tab !== activeId) ?? "welcome")) ?? activeNote;
   return (
     <div className="app-shell flex h-screen min-h-0 flex-col bg-miku-bg text-miku-text" data-theme={theme} data-ui-state-version={UI_STATE_VERSION}>
-      <LaunchBar onSearch={openSearch} theme={theme} onToggleTheme={toggleTheme} />
+      <LaunchBar
+        onSearch={openSearch}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+        mobileNavOpen={mobileNavOpen}
+        onToggleMobileNav={() => setMobileNavOpen((current) => !current)}
+        mobileNavButtonRef={mobileNavButtonRef}
+      />
       {searchOpen && (
         <div className="search-popover" ref={searchPanelRef} data-region="quick-open">
           <div className="search-popover-head">
@@ -363,6 +385,16 @@ export function WorkspaceScreen() {
         </div>
       )}
       <WorkspaceNotice message={notice} onDismiss={() => setNotice(null)} />
+      {mobileNavOpen && (
+        <button
+          className="mobile-nav-backdrop"
+          aria-label="Close workspace navigation"
+          onClick={() => {
+            setMobileNavOpen(false);
+            mobileNavButtonRef.current?.focus();
+          }}
+        />
+      )}
       <div
         className="workspace-layout flex h-[calc(100vh-var(--shell-topbar-height))] min-h-0 overflow-hidden"
         style={{ "--shell-sidebar-width": `${sidebarWidth}px`, "--shell-context-width": `${contextWidth}px` } as React.CSSProperties}
@@ -379,6 +411,11 @@ export function WorkspaceScreen() {
           onRecent={() => navigate("/recent")}
           onSettings={() => setSettingsOpen(true)}
           noteCount={workspace.data?.noteCount ?? 0}
+          mobileOpen={mobileNavOpen}
+          onCloseMobile={() => {
+            setMobileNavOpen(false);
+            mobileNavButtonRef.current?.focus();
+          }}
           onResizeStart={(event) => {
             event.preventDefault();
             resizingSidebar.current = true;

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -9,7 +9,7 @@ import { closeTab, normalizeNotePath, useNoteRouteRecovery } from "./noteRoute";
 import { UI_STATE_VERSION, moveSearchSelection, readTheme, shellRegions, writeTheme, type Theme } from "../../shared/ui";
 import { initialWorkspaceState, workspaceReducer } from "./state";
 
-const INDEX_NOTE_PATH = "Index.md";
+const INDEX_NOTE_PATH = "index.md";
 export function WorkspaceScreen() {
   const [state, dispatch] = useReducer(workspaceReducer, initialWorkspaceState);
   const [query, setQuery] = useState("");

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -47,6 +47,12 @@ export function WorkspaceScreen() {
   const workspace = useQuery({ queryKey: ["workspace"], queryFn: client.workspace });
   const tree = useQuery({ queryKey: ["tree"], queryFn: () => client.tree() });
   const folder = useQuery({ queryKey: ["folder", folderPath], queryFn: () => client.tree(folderPath), enabled: Boolean(folderPath) });
+
+  useEffect(() => {
+    const favicon = document.querySelector<HTMLLinkElement>("#miku-favicon");
+    if (favicon) favicon.href = `/miku-icon-${theme}.svg`;
+  }, [theme]);
+
   const context = useQuery({
     queryKey: ["context", activeId],
     queryFn: () => client.context(activeId),

--- a/miku-web/src/features/workspace/WorkspaceApp.tsx
+++ b/miku-web/src/features/workspace/WorkspaceApp.tsx
@@ -75,7 +75,10 @@ export function WorkspaceScreen() {
   });
   const isWorkspaceRoot = location.pathname === "/";
   const visibleTree = useMemo(() => [...(tree.data ?? []), ...(context.data?.children ?? [])], [context.data?.children, tree.data]);
-  const treeNotes = useMemo(() => visibleTree.map((node) => ({ ...node.note, icon: "file-text", updated: "indexed", body: "", backlinks: [], tags: [] })), [visibleTree]);
+  const treeNotes = useMemo(
+    () => visibleTree.map((node) => ({ ...node.note, icon: "file-text", frontmatter: {}, updated: "indexed", body: "", backlinks: [], tags: [] })),
+    [visibleTree]
+  );
   const contextualNote = useMemo(() => context.data?.note, [context.data]);
   useEffect(() => {
     if (!contextualNote) return;
@@ -124,6 +127,7 @@ export function WorkspaceScreen() {
       icon: "file-text",
       parents: [],
       aliases: [],
+      frontmatter: {},
       updated: "",
       body: "",
       backlinks: [],

--- a/miku-web/src/features/workspace/WorkspaceComponents.test.ts
+++ b/miku-web/src/features/workspace/WorkspaceComponents.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { curatedFrontmatter } from "./WorkspaceComponents";
+
+describe("curatedFrontmatter", () => {
+  it("orders meaningful properties and removes values rendered elsewhere", () => {
+    expect(
+      curatedFrontmatter({
+        impacts: ["miku-web"],
+        tags: ["miku"],
+        title: "Miku Note",
+        superseded_by: [],
+        status: "active",
+        type: "guide",
+        id: "guide-1",
+        note: null
+      })
+    ).toEqual([
+      ["type", "guide"],
+      ["status", "active"],
+      ["id", "guide-1"],
+      ["impacts", ["miku-web"]]
+    ]);
+  });
+});

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -26,10 +26,34 @@ function noteHeadings(markdown: string): { id: string; text: string; level: numb
   return headings;
 }
 
-export function LaunchBar({ onSearch, theme, onToggleTheme }: { onSearch: () => void; theme: "dark" | "light"; onToggleTheme: () => void }) {
+export function LaunchBar({
+  onSearch,
+  theme,
+  onToggleTheme,
+  mobileNavOpen,
+  onToggleMobileNav,
+  mobileNavButtonRef
+}: {
+  onSearch: () => void;
+  theme: "dark" | "light";
+  onToggleTheme: () => void;
+  mobileNavOpen: boolean;
+  onToggleMobileNav: () => void;
+  mobileNavButtonRef: React.RefObject<HTMLButtonElement | null>;
+}) {
   const navigate = useNavigate();
   return (
     <header className="launch-bar" data-region={shellRegions[0]}>
+      <button
+        ref={mobileNavButtonRef}
+        className="quiet-button mobile-nav-toggle"
+        aria-label={mobileNavOpen ? "Close workspace navigation" : "Open workspace navigation"}
+        aria-controls="workspace-navigation"
+        aria-expanded={mobileNavOpen}
+        onClick={onToggleMobileNav}
+      >
+        <ActionIcon name={mobileNavOpen ? "close" : "menu"} />
+      </button>
       <button className="brand-mark" onClick={() => navigate("/")} aria-label="Go to workspace home">
         <img className="brand-icon" src={`/miku-icon-${theme}.svg`} alt="" />
         <span>miku note</span>
@@ -60,7 +84,9 @@ export function Sidebar({
   onRecent,
   onSettings,
   noteCount,
-  onResizeStart
+  onResizeStart,
+  mobileOpen,
+  onCloseMobile
 }: {
   notes: NoteModel[];
   nodes: TreeNodeModel[];
@@ -74,12 +100,17 @@ export function Sidebar({
   onSettings: () => void;
   noteCount: number;
   onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  mobileOpen: boolean;
+  onCloseMobile: () => void;
 }) {
   return (
-    <aside className="sidebar" data-region={shellRegions[1]}>
+    <aside id="workspace-navigation" className={`sidebar ${mobileOpen ? "is-mobile-open" : ""}`} data-region={shellRegions[1]} aria-label="Workspace navigation">
       <button className="sidebar-resizer" onPointerDown={onResizeStart} aria-label="Resize workspace navigation" />
       <div className="sidebar-toolbar">
         <span className="eyebrow">Workspace</span>
+        <button className="tool-button mobile-nav-close" onClick={onCloseMobile} aria-label="Close workspace navigation">
+          <ActionIcon name="close" />
+        </button>
         <button
           className={`tool-button ${hoisted ? "is-on" : ""}`}
           onClick={onToggleHoist}

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -94,7 +94,7 @@ export function Sidebar({
         <span>All notes</span>
         <span className="count-pill">{noteCount}</span>
       </div>
-      <WorkspaceTree notes={notes} nodes={nodes} activeId={activeId} onSelect={onSelect} hoisted={hoisted} client={client} />
+      <WorkspaceTree notes={notes} nodes={nodes} activeId={activeId} onSelect={onSelect} hoisted={hoisted} onExpandTree={onToggleHoist} client={client} />
       <div className="sidebar-bottom">
         <button className="sidebar-link" onClick={onRecent}>
           <ActionIcon name="clock" /> Recent

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -10,6 +10,31 @@ import { extractOutgoingLinks } from "../markdown/noteLinks";
 
 const MarkdownEditor = lazy(() => import("../markdown/MarkdownEditor"));
 const MarkdownReader = lazy(() => import("../markdown/MarkdownReader").then((module) => ({ default: module.MarkdownReader })));
+const FRONTMATTER_ORDER = ["type", "status", "id", "slug", "aliases", "parents", "updated"] as const;
+const FRONTMATTER_HIDDEN = new Set(["title", "tags", "icon"]);
+
+export function curatedFrontmatter(frontmatter: Record<string, unknown>): [string, unknown][] {
+  const rank = new Map<string, number>(FRONTMATTER_ORDER.map((key, index) => [key, index]));
+  return Object.entries(frontmatter)
+    .filter(([key, value]) => !FRONTMATTER_HIDDEN.has(key) && value !== null && value !== "" && !(Array.isArray(value) && value.length === 0))
+    .sort(([left], [right]) => (rank.get(left) ?? FRONTMATTER_ORDER.length) - (rank.get(right) ?? FRONTMATTER_ORDER.length) || left.localeCompare(right));
+}
+
+function FrontmatterValue({ value }: { value: unknown }) {
+  if (Array.isArray(value)) {
+    return (
+      <span className="frontmatter-values">
+        {value.map((item, index) => (
+          <span className="frontmatter-value" key={`${String(item)}-${index}`}>
+            {String(item)}
+          </span>
+        ))}
+      </span>
+    );
+  }
+  if (typeof value === "object" && value !== null) return <code>{JSON.stringify(value)}</code>;
+  return <span className="frontmatter-value">{String(value)}</span>;
+}
 
 function noteHeadings(markdown: string): { id: string; text: string; level: number }[] {
   const headings: { id: string; text: string; level: number }[] = [];
@@ -232,6 +257,10 @@ export function NotePane({
   const [draft, setDraft] = useState(note.body);
   const [saveState, setSaveState] = useState("saved");
   const [sourceMode, setSourceMode] = useState(false);
+  const properties = curatedFrontmatter(note.frontmatter).filter(([key]) => key !== "id" || !note.identityGenerated);
+  const frontmatterTags = Array.isArray(note.frontmatter.tags)
+    ? note.frontmatter.tags.filter((tag): tag is string => typeof tag === "string").map((tag) => tag.replace(/^#/, ""))
+    : [];
   useEffect(() => {
     setDraft(note.body);
     setSaveState("saved");
@@ -302,33 +331,38 @@ export function NotePane({
           </span>
           <div className="note-heading-copy">
             <h1>{note.title}</h1>
-            <ul className="note-meta-list">
-              <li>
-                <span className="meta-label">type</span> Markdown note
-              </li>
-              <li>
-                <span className="meta-label">status</span>{" "}
-                <span className="saved-state">
-                  <span className="saved-dot" /> {sourceMode ? saveState : "reading"}
-                </span>
-              </li>
-              <li>
-                <span className="meta-label">updated</span> {note.updated}
-              </li>
-              {note.tags.length > 0 && (
-                <li className="note-meta-tags">
-                  <span className="tag-row">
-                    {note.tags.map((tag) => (
-                      <button className="tag" key={tag} onClick={() => onTagSearch(tag)}>
-                        #{tag}
-                      </button>
-                    ))}
-                  </span>
-                </li>
-              )}
-            </ul>
+            <div className="note-file-state">
+              <span className="saved-state">
+                <span className="saved-dot" /> {sourceMode ? saveState : "reading"}
+              </span>
+              {!Object.hasOwn(note.frontmatter, "updated") && <span>Modified {note.updated}</span>}
+            </div>
           </div>
         </div>
+        {(properties.length > 0 || frontmatterTags.length > 0) && (
+          <dl className="frontmatter-panel" aria-label="Frontmatter properties">
+            {properties.map(([key, value]) => (
+              <div className="frontmatter-row" key={key}>
+                <dt>{key}</dt>
+                <dd>
+                  <FrontmatterValue value={value} />
+                </dd>
+              </div>
+            ))}
+            {frontmatterTags.length > 0 && (
+              <div className="frontmatter-row">
+                <dt>tags</dt>
+                <dd className="tag-row">
+                  {frontmatterTags.map((tag) => (
+                    <button className="tag" key={tag} onClick={() => onTagSearch(tag)}>
+                      #{tag}
+                    </button>
+                  ))}
+                </dd>
+              </div>
+            )}
+          </dl>
+        )}
         {sourceMode ? (
           <Suspense fallback={<div className="markdown-editor-loading">Loading editor…</div>}>
             <MarkdownEditor

--- a/miku-web/src/features/workspace/WorkspaceComponents.tsx
+++ b/miku-web/src/features/workspace/WorkspaceComponents.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { createWorkspaceClient, sortTreeNodes, type BacklinkModel, type NoteModel, type OutgoingLinkModel, type TreeNodeModel } from "./api";
 import { normalizeNotePath } from "./noteRoute";
@@ -10,6 +10,7 @@ import { extractOutgoingLinks } from "../markdown/noteLinks";
 
 const MarkdownEditor = lazy(() => import("../markdown/MarkdownEditor"));
 const MarkdownReader = lazy(() => import("../markdown/MarkdownReader").then((module) => ({ default: module.MarkdownReader })));
+const TAG_PAGE_SIZE = 50;
 const FRONTMATTER_ORDER = ["type", "status", "id", "slug", "aliases", "parents", "updated"] as const;
 const FRONTMATTER_HIDDEN = new Set(["title", "tags", "icon"]);
 
@@ -548,24 +549,28 @@ export function WorkspaceUtility({
   const navigate = useNavigate();
   const wildcard = useParams()["*"] ?? "";
   const tag = route === "tags" && wildcard ? decodeURIComponent(wildcard) : "";
-  const tags = useQuery({ queryKey: ["tags"], queryFn: client.tags, enabled: route === "tags" });
+  const tags = useInfiniteQuery({
+    queryKey: ["tags"],
+    queryFn: ({ pageParam }) => client.tags(pageParam, TAG_PAGE_SIZE),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, pages) => (lastPage.length < TAG_PAGE_SIZE ? undefined : pages.length * TAG_PAGE_SIZE),
+    enabled: route === "tags"
+  });
   const tagNotes = useQuery({ queryKey: ["tag-notes", tag], queryFn: () => client.tagNotes(tag), enabled: route === "tags" && Boolean(tag) });
-  const [tagLimit, setTagLimit] = useState(10);
   const tagSentinelRef = useRef<HTMLDivElement>(null);
   const recent = route === "recent" ? (JSON.parse(localStorage.getItem("miku-recent") ?? "[]") as string[]).slice(0, 20) : [];
-  const visibleTags = tags.data?.slice(0, tagLimit) ?? [];
-  useEffect(() => setTagLimit(10), [tags.data]);
+  const visibleTags = tags.data?.pages.flat() ?? [];
   useEffect(() => {
     if (route !== "tags" || tag || !tagSentinelRef.current) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting) setTagLimit((current) => Math.min(current + 10, tags.data?.length ?? current));
+        if (entries[0]?.isIntersecting && tags.hasNextPage && !tags.isFetchingNextPage) void tags.fetchNextPage();
       },
       { rootMargin: "120px" }
     );
     observer.observe(tagSentinelRef.current);
     return () => observer.disconnect();
-  }, [route, tag, tags.data]);
+  }, [route, tag, tags.fetchNextPage, tags.hasNextPage, tags.isFetchingNextPage]);
   return (
     <div className="workspace-utility" data-theme={theme}>
       <div className="utility-page-header">

--- a/miku-web/src/features/workspace/api.ts
+++ b/miku-web/src/features/workspace/api.ts
@@ -10,6 +10,7 @@ export type NoteModel = {
   icon: string;
   parents: string[];
   aliases: string[];
+  frontmatter: Record<string, unknown>;
   updated: string;
   body: string;
   backlinks: string[];
@@ -124,6 +125,7 @@ function normalizeNote(note: Schemas["NoteResponse"]): NoteModel {
     icon: typeof frontmatter.icon === "string" ? frontmatter.icon : "file-text",
     parents: Array.isArray(frontmatter.parents) ? frontmatter.parents.filter((parent): parent is string => typeof parent === "string") : [],
     aliases: Array.isArray(frontmatter.aliases) ? frontmatter.aliases.filter((alias): alias is string => typeof alias === "string") : [],
+    frontmatter,
     updated: formatUpdatedAt(note.revision.mtime),
     body: note.body,
     backlinks: [],

--- a/miku-web/src/features/workspace/api.ts
+++ b/miku-web/src/features/workspace/api.ts
@@ -238,7 +238,7 @@ export function createWorkspaceClient(onSource: (source: ApiSource) => void) {
         const response = await request<Schemas["SearchResponse"]>(`/api/v1/search?${params}`);
         return response.results.map((result) => ({ ...result, id: result.path, icon: "file-text" }));
       }),
-    tags: (): Promise<TagModel[]> => live(() => request<Schemas["TagResponse"][]>("/api/v1/tags")),
+    tags: (offset = 0, limit = 50): Promise<TagModel[]> => live(() => request<Schemas["TagResponse"][]>(`/api/v1/tags?offset=${offset}&limit=${limit}`)),
     tagNotes: (tag: string): Promise<TagNoteModel[]> => live(() => request<Schemas["TagNoteResponse"][]>(`/api/v1/tags/${encodeURIComponent(tag)}/notes`))
   };
 }

--- a/miku-web/src/features/workspace/generated/api.ts
+++ b/miku-web/src/features/workspace/generated/api.ts
@@ -458,7 +458,12 @@ export interface operations {
   };
   tags: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum tags returned per page (default 50, maximum 200). */
+        limit?: number;
+        /** @description Number of sorted tags to skip. */
+        offset?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;

--- a/miku-web/src/features/workspace/noteRoute.test.ts
+++ b/miku-web/src/features/workspace/noteRoute.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import { createRef } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { closeTab, normalizeNotePath, useNoteRouteRecovery } from "./noteRoute";
 
@@ -17,6 +18,7 @@ describe("useNoteRouteRecovery", () => {
     isNoteRoute: true,
     isError: false,
     hasNote: true,
+    closingIdRef: createRef<string | null>(),
     tabs: [] as string[],
     dispatch: vi.fn(),
     navigate: vi.fn() as unknown as NavigateFunction,
@@ -44,6 +46,13 @@ describe("useNoteRouteRecovery", () => {
     const options = baseOptions();
     renderHook(() => useNoteRouteRecovery({ ...options, canonicalId: undefined }));
     expect(options.dispatch).toHaveBeenCalledWith({ type: "open", id: "target-title.md" });
+  });
+
+  it("does not reopen the active route while its tab is closing", () => {
+    const options = baseOptions();
+    options.closingIdRef.current = "target-title.md";
+    renderHook(() => useNoteRouteRecovery({ ...options, canonicalId: "target-title.md" }));
+    expect(options.dispatch).not.toHaveBeenCalled();
   });
 });
 

--- a/miku-web/src/features/workspace/noteRoute.ts
+++ b/miku-web/src/features/workspace/noteRoute.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type Dispatch } from "react";
+import { useEffect, useRef, type Dispatch, type MutableRefObject } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import type { WorkspaceAction } from "./state";
 
@@ -50,13 +50,14 @@ type NoteRouteRecoveryOptions = {
    * redirect lands and re-opens under the canonical id instead.
    */
   canonicalId?: string;
+  closingIdRef: MutableRefObject<string | null>;
   tabs: string[];
   dispatch: Dispatch<WorkspaceAction>;
   navigate: NavigateFunction;
   setNotice: (notice: string) => void;
 };
 
-export function useNoteRouteRecovery({ activeId, isNoteRoute, isError, hasNote, canonicalId, tabs, dispatch, navigate, setNotice }: NoteRouteRecoveryOptions): void {
+export function useNoteRouteRecovery({ activeId, isNoteRoute, isError, hasNote, canonicalId, closingIdRef, tabs, dispatch, navigate, setNotice }: NoteRouteRecoveryOptions): void {
   const handledInvalidRoute = useRef<string | null>(null);
 
   useEffect(() => {
@@ -82,9 +83,13 @@ export function useNoteRouteRecovery({ activeId, isNoteRoute, isError, hasNote, 
       return;
     }
     handledInvalidRoute.current = null;
+    if (closingIdRef.current && closingIdRef.current !== normActiveId) {
+      closingIdRef.current = null;
+    }
     const awaitingCanonicalRedirect = canonicalId !== undefined && canonicalId !== normActiveId;
-    if (hasNote && !awaitingCanonicalRedirect && !tabs.map(normalizeNotePath).includes(normActiveId)) {
+    const closingCurrentRoute = closingIdRef.current === normActiveId;
+    if (hasNote && !awaitingCanonicalRedirect && !closingCurrentRoute && !tabs.map(normalizeNotePath).includes(normActiveId)) {
       dispatch({ type: "open", id: normActiveId });
     }
-  }, [activeId, canonicalId, dispatch, hasNote, isError, isNoteRoute, navigate, setNotice, tabs]);
+  }, [activeId, canonicalId, closingIdRef, dispatch, hasNote, isError, isNoteRoute, navigate, setNotice, tabs]);
 }

--- a/miku-web/src/styles.css
+++ b/miku-web/src/styles.css
@@ -75,6 +75,22 @@
 }
 * {
   box-sizing: border-box;
+  scrollbar-color: color-mix(in srgb, var(--faint) 62%, transparent) transparent;
+  scrollbar-width: thin;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+  background: transparent;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--faint) 62%, transparent);
+  background-clip: content-box;
 }
 body {
   margin: 0;
@@ -114,6 +130,7 @@ input:focus-visible {
   font-size: 1.15em;
 }
 .app-shell {
+  color-scheme: dark;
   color: var(--text);
   background: var(--bg);
 }
@@ -249,6 +266,11 @@ input:focus-visible {
 .quiet-button:hover,
 .tool-button:hover {
   color: var(--text);
+}
+.mobile-nav-toggle,
+.mobile-nav-close,
+.mobile-nav-backdrop {
+  display: none;
 }
 .workspace-layout {
 }
@@ -1542,6 +1564,28 @@ input:focus-visible {
   .brand-mark {
     width: auto;
   }
+  .brand-mark span {
+    display: none;
+  }
+  .mobile-nav-toggle,
+  .mobile-nav-close {
+    display: inline-flex;
+  }
+  .mobile-nav-toggle {
+    flex: 0 0 auto;
+  }
+  .mobile-nav-backdrop {
+    display: block;
+    position: fixed;
+    z-index: 19;
+    inset: var(--shell-topbar-height) 0 0;
+    width: 100%;
+    height: auto;
+    border: 0;
+    border-radius: 0;
+    background: rgb(0 0 0 / 42%);
+    backdrop-filter: blur(2px);
+  }
   .workspace-source {
     display: none;
   }
@@ -1552,7 +1596,29 @@ input:focus-visible {
     display: none;
   }
   .sidebar {
-    flex-basis: 200px;
+    position: fixed;
+    z-index: 20;
+    top: var(--shell-topbar-height);
+    bottom: 0;
+    left: 0;
+    width: min(84vw, 320px);
+    max-width: 320px;
+    flex-basis: auto;
+    box-shadow: 16px 0 40px rgb(0 0 0 / 24%);
+    transform: translateX(-105%);
+    transition: transform 160ms ease;
+  }
+  .sidebar.is-mobile-open {
+    transform: translateX(0);
+  }
+  .sidebar-resizer {
+    display: none;
+  }
+  .sidebar-toolbar {
+    gap: 6px;
+  }
+  .sidebar-toolbar .mobile-nav-close {
+    order: 2;
   }
   .context-panel {
     display: none;
@@ -1579,6 +1645,11 @@ input:focus-visible {
   }
   .note-pane.is-split {
     min-width: 0;
+  }
+}
+@media (max-width: 760px) and (prefers-reduced-motion: reduce) {
+  .sidebar {
+    transition: none;
   }
 }
 [data-theme="light"] {
@@ -1608,6 +1679,9 @@ input:focus-visible {
   --reader-border: #e9e9e7;
   --reader-muted: #787774;
   --relation: #805ad5;
+}
+[data-theme="light"] {
+  color-scheme: light;
 }
 [data-theme="light"] .launch-bar {
   background: color-mix(in srgb, var(--panel) 92%, transparent);

--- a/miku-web/src/styles.css
+++ b/miku-web/src/styles.css
@@ -710,36 +710,55 @@ input:focus-visible {
   letter-spacing: -0.04em;
   line-height: 1.1;
 }
-.note-meta-list {
-  margin: 0;
-  padding-left: 18px;
-  list-style: disc;
-  color: var(--muted);
-  font-size: 0.72rem;
-  line-height: 1.8;
-}
-.note-meta-list li::marker {
-  color: var(--accent);
-}
-.note-meta-list .note-meta-tags {
-  margin-left: -18px;
-  list-style: none;
-}
-.note-meta-list code {
+.note-file-state {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  margin-top: 8px;
   color: var(--faint);
-  font: inherit;
-  overflow-wrap: anywhere;
+  font-size: 0.68rem;
 }
-.meta-label {
-  display: inline-block;
-  min-width: 54px;
-  margin-right: 5px;
+.note-file-state .saved-state {
+  display: inline-flex;
+}
+.frontmatter-panel {
+  display: grid;
+  grid-template-columns: minmax(88px, max-content) minmax(0, 1fr);
+  margin: -8px 0 30px 56px;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  font-size: 0.72rem;
+}
+.frontmatter-row {
+  display: contents;
+}
+.frontmatter-row dt,
+.frontmatter-row dd {
+  min-width: 0;
+  margin: 0;
+  padding: 5px 10px;
+}
+.frontmatter-row dt {
   color: var(--faint);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.66rem;
 }
-.note-meta-list .saved-state {
-  display: inline-flex;
+.frontmatter-row dd {
+  color: var(--reader-muted);
+  overflow-wrap: anywhere;
+}
+.frontmatter-row code {
+  color: inherit;
+  font: inherit;
+}
+.frontmatter-values,
+.frontmatter-row .tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.frontmatter-value {
+  color: var(--reader-text);
 }
 .tag-row {
   display: flex;
@@ -1628,6 +1647,9 @@ input:focus-visible {
   }
   .note-scroll {
     padding: 32px 20px 48px;
+  }
+  .frontmatter-panel {
+    margin-left: 0;
   }
   .note-toolbar {
     padding-inline: 16px;

--- a/miku-web/src/styles.css
+++ b/miku-web/src/styles.css
@@ -724,7 +724,7 @@ input:focus-visible {
 .frontmatter-panel {
   display: grid;
   grid-template-columns: minmax(88px, max-content) minmax(0, 1fr);
-  margin: -8px 0 30px 56px;
+  margin: -8px auto 30px;
   padding: 10px 0;
   border-top: 1px solid var(--line);
   border-bottom: 1px solid var(--line);
@@ -1647,9 +1647,6 @@ input:focus-visible {
   }
   .note-scroll {
     padding: 32px 20px 48px;
-  }
-  .frontmatter-panel {
-    margin-left: 0;
   }
   .note-toolbar {
     padding-inline: 16px;

--- a/miku_docs/Changelog.md
+++ b/miku_docs/Changelog.md
@@ -3,12 +3,21 @@ title: Changelog
 type: changelog
 status: active
 tags: [miku, release]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Changelog
 
 User-facing changes to Miku Note are recorded here. See [[Index]] for the starting point and [[Features]] for the current product boundary. #release
+
+## v0.0.5 — workspace consistency and SQLite-only search (2026-07-29)
+
+- Removed Tantivy and SQLite FTS5; SQLite now stores one body copy and performs parallel plain-content search, while MemoryIndex retains only graph metadata.
+- Added backend-resolved outgoing links, ignored links inside inline/fenced code, and corrected lazy tree parent/expansion behavior.
+- Added an accessible mobile navigation drawer, calmer dark scrollbars, theme-aware favicon behavior, and curated real frontmatter properties.
+- Fixed active tabs reopening during close navigation and cleared quick-search input after selecting a note.
+- Reduced folder tree reads to one representative row per immediate child and kept folder-scoped parent IDs consistent.
+- Folded the former workspace-cleanup unreleased notes into the shipped v0.0.3 record below.
 
 ## v0.0.4 — note save performance & trilium editor layout (2026-07-28)
 
@@ -27,9 +36,6 @@ User-facing changes to Miku Note are recorded here. See [[Index]] for the starti
 - Added Mermaid, GitHub-style alerts, KaTeX math, table-of-contents navigation, lazy tags, and folder/file browsing to the reader surface.
 - Fixed language-less and highlighted code blocks so their contrast, padding, scrolling, and theme colors remain readable in both light and dark mode.
 - Split the Rust workspace into domain, vault, Markdown, index, cache, application, and HTTP layers with SQLite as the default durable projection.
-
-## Unreleased — workspace cleanup (2026-07-16)
-
 - Replaced the former server-rendered/Alpine frontend description with the current React, Vite, Tailwind, Prism, Mermaid, and KaTeX architecture.
 - Organized the frontend source by app, workspace, Markdown, components, and shared helpers.
 - Removed duplicate planning notes and stale pre-workspace documentation.

--- a/miku_docs/Changelog.md
+++ b/miku_docs/Changelog.md
@@ -17,6 +17,7 @@ User-facing changes to Miku Note are recorded here. See [[Index]] for the starti
 - Added an accessible mobile navigation drawer, calmer dark scrollbars, theme-aware favicon behavior, and curated real frontmatter properties.
 - Fixed active tabs reopening during close navigation and cleared quick-search input after selecting a note.
 - Reduced folder tree reads to one representative row per immediate child and kept folder-scoped parent IDs consistent.
+- Replaced client-only tag slicing with bounded `/api/v1/tags` pagination and incremental page fetching.
 - Folded the former workspace-cleanup unreleased notes into the shipped v0.0.3 record below.
 
 ## v0.0.4 — note save performance & trilium editor layout (2026-07-28)

--- a/miku_docs/Features.md
+++ b/miku_docs/Features.md
@@ -3,7 +3,7 @@ title: Miku Note Features
 type: guide
 status: active
 tags: [miku, features, markdown]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Miku Note Features
@@ -101,8 +101,8 @@ tags: [project/miku, markdown]
 This note is also discoverable through #project/miku.
 ```
 
-Tags are clickable in the note metadata and Context panel. The Tags page starts with ten tags and loads another ten when its list reaches the scroll sentinel; selecting a tag opens its indexed note
-list.
+Tags are clickable in note properties. The Tags page fetches 50 indexed tags at a time and requests the next API page when its list reaches the scroll sentinel; selecting a tag opens its indexed note
+list. Tag results remain server-owned derived data and are not copied into browser localStorage.
 
 - `/tags` shows the tag index and loads more results as you scroll;
 - `/tags/<tag>` shows matching pages and also uses scroll-triggered paging;

--- a/miku_docs/adr/0014-native-local-backend.md
+++ b/miku_docs/adr/0014-native-local-backend.md
@@ -4,7 +4,7 @@ type: adr
 title: ADR-0014 — Native local backend
 slug: native-local-backend
 status: Superseded by ADR-0016
-updated: 2026-07-14
+updated: 2026-07-29
 date-proposed: 2026-07-14
 date-accepted: 2026-07-14
 deciders: [haru]
@@ -24,4 +24,4 @@ This decision is superseded by ADR-0016. It is retained as the numbered decision
 ## Current boundary
 
 The local runtime selects SQLite with `MIKU_INDEX_BACKEND=sqlite` and stores the database at `miku_docs/.miku-index.sqlite` by default. The backend implements the domain contract through SQLx and
-SQLite FTS5.
+a plain `TEXT` body column searched in parallel Rust code; ADR-0020 removed FTS5 and Tantivy.

--- a/miku_docs/adr/0015-derived-unlinked-mention-index.md
+++ b/miku_docs/adr/0015-derived-unlinked-mention-index.md
@@ -3,7 +3,7 @@ id: ADR-0015
 type: adr
 title: ADR-0015 — Derived unlinked-mention index
 status: Accepted
-updated: 2026-07-14
+updated: 2026-07-29
 date-accepted: 2026-07-14
 mirror: asobi:miku:decision:derived-unlinked-mention-index
 tags: [index, links, mentions]
@@ -25,8 +25,8 @@ frontmatter, and self-references. The page route will only read this relation; i
 The durable page projection remains the source for rebuilding the relation. The relation is disposable and may be empty or stale while reconciliation is running. Linked forward links and backlinks
 remain authoritative and immediately available through the normal index projection.
 
-SQLite FTS5 remains the general-purpose full-text candidate/search engine. It may accelerate a rebuild or provide a fallback candidate set, but it is not the source of truth for mention semantics or
-promotion safety.
+SQLite plain-content search remains the general-purpose search engine. It may accelerate a rebuild or provide a fallback candidate set, but it is not the source of truth for mention semantics or
+promotion safety. ADR-0020 replaced the earlier FTS5 implementation.
 
 ## Why
 

--- a/miku_docs/adr/0018-composed-projections.md
+++ b/miku_docs/adr/0018-composed-projections.md
@@ -4,7 +4,7 @@ type: adr
 title: ADR-0018 — Composed durable and hot projections
 slug: composed-projections
 status: Superseded by ADR-0020
-updated: 2026-07-28
+updated: 2026-07-29
 date-proposed: 2026-07-16
 date-accepted: 2026-07-16
 deciders: [haru]
@@ -19,8 +19,8 @@ tags: [architecture, projections, tantivy, sqlite, valkey, postgres]
 ## Status
 
 Superseded by ADR-0020 for the search/Tantivy framing specifically: this record's "hot projection: MemoryIndex (page graph + Tantivy)" and its measured "hot Tantivy rebuild" restart cost
-(Implementation status below) no longer describe the system — Tantivy is removed, and SQLite FTS5 is the sole search projection regardless of `ready` state. The durable+hot composition boundary and
-`ready`-gated reader switch this record establishes remain in effect for page-graph reads; only the search-engine choice changes.
+(Implementation status below) no longer describe the system—Tantivy and FTS5 are removed. The durable+hot composition boundary and
+`ready`-gated reader switch this record establishes remain in effect for page-graph reads; current search uses SQLite's plain body column regardless of graph readiness.
 
 ## Decision
 

--- a/miku_docs/adr/0019-document-graph-index.md
+++ b/miku_docs/adr/0019-document-graph-index.md
@@ -4,19 +4,24 @@ type: adr
 title: ADR-0019 — In-memory document-graph index
 slug: document-graph-index
 status: Accepted
-updated: 2026-07-28
+updated: 2026-07-29
 date-proposed: 2026-07-28
 date-accepted: 2026-07-28
 deciders: [haru]
 mirror: asobi:miku:decision:document-graph-index
 supersedes: []
 superseded-by:
-relates-to: [ADR-0009, ADR-0015, ADR-0016, ADR-0018]
+relates-to: [ADR-0009, ADR-0015, ADR-0016, ADR-0018, ADR-0020]
 impacts: [crates/miku-domain, crates/miku-index-memory, crates/miku-index-sqlite]
 tags: [index, links, performance, architecture]
 ---
 
 # ADR-0019 — In-memory document-graph index
+
+## Current status
+
+The in-memory graph decision remains active. ADR-0020 supersedes this record's historical FTS5/Tantivy search details and completed the memory-cap follow-up by moving body search to SQLite's plain
+`TEXT` column and stripping bodies from MemoryIndex.
 
 ## Decision
 
@@ -51,7 +56,7 @@ That estimate describes the graph structures only. It does **not** cover, and wa
 - Accepted that the page graph becomes fully process-local and rebuilds from scratch on cold start; this is consistent with ADR-0018's existing hot-projection rebuild behavior for Tantivy and does not introduce a new consistency risk.
 - Deferred alias- and tag-index restructuring beyond what is needed for slug/backlink resolution; `tb_tags`/`tb_page_aliases` removal from the relational schema follows once the memory-side structures cover the same queries.
 
-## Implementation status
+## Historical implementation status before ADR-0020
 
 **Partially implemented.** The link-graph resolution work is done: `crates/miku-index-memory` resolves links via `LinkGraph`'s `slug_index`/`path_index` with incremental `upsert_page`/`remove_page` (no full-corpus rebuild on single-page writes), and `crates/miku-index-sqlite` no longer performs relational link/tag/alias resolution; `tb_links`, `tb_tags`, and `tb_page_aliases` are removed from the schema. This part was tracked as `miku:document-graph-index` in asobi (tasks 1-5, all DONE).
 

--- a/miku_docs/adr/readme.md
+++ b/miku_docs/adr/readme.md
@@ -1,5 +1,7 @@
 ---
 title: Architecture Decision Records
+aliases:
+  - README
 type: index
 status: active
 tags: [miku, architecture, adr]

--- a/miku_docs/api.md
+++ b/miku_docs/api.md
@@ -3,7 +3,7 @@ title: Miku HTTP API
 type: reference
 status: active
 tags: [miku, api, rust]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Miku HTTP API
@@ -34,10 +34,12 @@ All application JSON routes use the /api/v1 prefix.
 | GET    | /api/v1/note-context/{id}  | Note, metadata, backlinks, and context    |
 | GET    | /api/v1/note-children/{id} | Child placements for a note               |
 | GET    | /api/v1/search             | Title, content, or combined search        |
-| GET    | /api/v1/tags               | Indexed tags and counts                   |
+| GET    | /api/v1/tags               | Indexed tags and counts (`limit`/`offset`) |
 | GET    | /api/v1/tags/{tag}/notes   | Notes carrying one tag                    |
 
 The {id} value is a URL-encoded Markdown-relative path, normally ending in .md. The API never exposes a workspace-root label as a user-facing breadcrumb.
+
+`GET /api/v1/tags` returns 50 tags by default, accepts `offset`, and caps `limit` at 200. The browser requests subsequent pages only as the tag list scrolls.
 
 ## Save contract
 

--- a/miku_docs/architecture.md
+++ b/miku_docs/architecture.md
@@ -3,7 +3,7 @@ title: Miku Architecture
 type: architecture
 status: active
 tags: [miku, architecture, rust, markdown]
-updated: 2026-07-28
+updated: 2026-07-29
 ---
 
 # Miku Architecture
@@ -36,8 +36,8 @@ miku_docs/\*_/_.md and user assets are authoritative. miku-vault owns safe path 
 miku-domain defines the stable vocabulary shared by the vault, indexer, application, and projection backends: notes, links, tags, revisions, search requests, and index capabilities. It intentionally
 contains no filesystem or database implementation.
 
-The index is disposable. The default runtime composes a local SQLite durable projection with an in-memory/Tantivy hot projection. Postgres and Valkey are optional scale components. Rebuilding any
-projection from miku_docs/ must recover the same searchable relationships.
+The index is disposable. The default runtime uses local SQLite for durable metadata and full-text search, with MemoryIndex as a rebuildable in-process graph projection. Postgres and Valkey are
+optional scale components. Tantivy was removed by ADR-0020. Rebuilding any projection from miku_docs/ must recover the same searchable relationships.
 
 ## Runtime flow
 
@@ -50,10 +50,10 @@ projection from miku_docs/ must recover the same searchable relationships.
 HTTP handlers read projections and source documents. They do not synchronously rebuild indexes. A save writes atomically; the watcher schedules reconciliation. Startup reconciliation catches changes
 missed while the process was stopped.
 
-## Reconcile and hot-projection rebuild, as implemented
+## Historical reconcile and Tantivy rebuild (pre-ADR-0020)
 
-This section documents actual current behavior, verified against the code at the line numbers cited, not an idealized description. It exists because the workflow has a real, non-obvious constraint
-(below) that any future change to page-body memory handling must not silently break.
+This section preserves the measured pre-ADR-0020 workflow that motivated removal of Tantivy. It is historical evidence, not current runtime documentation. The current implementation stores bodies
+once in SQLite, searches its plain body column in parallel Rust code, and keeps body-free graph metadata in MemoryIndex. See ADR-0020 and “What is actually stored where” below.
 
 ### User story: editing one note while Miku is running
 
@@ -163,7 +163,7 @@ Four separate stores exist, not one "index." None of them holds the same shape o
 Opening a note is read-only. It never writes to SQLite or `MemoryIndex`, and never triggers a reconcile. `GET /api/v1/notes/{id}` (`crates/miku/src/http_api.rs:220-231`) calls
 `application.read_note` → `resolve_document` (`crates/miku-app/src/application.rs:111-145`), which:
 
-1. Checks `self.index.page(path)` — a cheap existence/metadata check against whichever projection is currently `active()` (SQLite before `ready`, `MemoryIndex` after). This never returns a body.
+1. Checks `self.index.page(path)` against the durable projection—a cheap existence/metadata check that never returns a body.
 2. Calls `read_document_path` (`application.rs:99-109`), which checks the 128-entry `documents_cache` **first**. On hit, returns the cached `VaultDocument` — no disk read, no index touched.
 3. On a cache miss, reads the file directly from disk via `self.vault.read(path)` (`application.rs:103`), then inserts it into `documents_cache`, evicting the least-recently-touched entry if the cache
    is already at 128.
@@ -177,7 +177,7 @@ channel the reconcile workflow above sends on). So editing *any* file, even one 
 ```mermaid
 flowchart TD
     A["GET /api/v1/notes/:id"] --> B["resolve_document (application.rs:111)"]
-    B --> C["index.page(path): SQLite if not ready, else MemoryIndex — metadata only, no body"]
+    B --> C["index.page(path): durable projection metadata only, no body"]
     C -->|not found| D[404]
     C -->|found| E["read_document_path (application.rs:99)"]
     E --> F{in documents_cache LRU, 128 entries?}
@@ -222,4 +222,3 @@ The frontend performs zero global page prefetching or client-side link resolutio
 1. OS Filesystem Events (`notify` watcher) for local disk file edits.
 2. Synchronous `save_note()` writes (`ComposedIndexWriter`) for Web UI edits.
 3. Startup file mtime reconcile sweeps (`reconcile_store()`) on server restarts.
-

--- a/miku_docs/changelog.md
+++ b/miku_docs/changelog.md
@@ -8,7 +8,7 @@ updated: 2026-07-29
 
 # Changelog
 
-User-facing changes to Miku Note are recorded here. See [[Index]] for the starting point and [[Features]] for the current product boundary. #release
+User-facing changes to Miku Note are recorded here. See [[index|Miku Note]] for the starting point and [[features|Features]] for the current product boundary. #release
 
 ## v0.0.5 — workspace consistency and SQLite-only search (2026-07-29)
 
@@ -66,7 +66,7 @@ User-facing changes to Miku Note are recorded here. See [[Index]] for the starti
 - Added lazy Mermaid rendering with diagram zoom.
 - Added lazy Prism highlighting and code-block copy actions.
 - Added dollar math parsing and lazy KaTeX rendering for inline `$...$` and display `$$...$$` equations.
-- Updated [[Sandbox]] with Mermaid, code, and math fixtures for browser acceptance checks.
+- Updated [[sandbox|Sandbox]] with Mermaid, code, and math fixtures for browser acceptance checks.
 
 ### Scope clarification
 

--- a/miku_docs/dataflow.md
+++ b/miku_docs/dataflow.md
@@ -3,7 +3,7 @@ title: Miku Dataflow
 type: architecture
 status: active
 tags: [miku, architecture, dataflow, mermaid]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Dataflow & Workflows
@@ -12,12 +12,12 @@ All diagrams are Mermaid. See `miku_docs/architecture.md` for the prose design a
 
 ## 1. System overview
 
-Files are the source of truth; the memory graph plus Tantivy are the default disposable projections, with SQLite and Postgres available as explicit profiles. HTTP handlers only **read** the index; the
-background indexer is the **only** writer.
+Files are the source of truth. SQLite is the default durable metadata and search projection, while MemoryIndex supplies the disposable in-process graph. Postgres remains an explicit profile. HTTP
+handlers only **read** projections; the background indexer is the **only** writer.
 
 ```mermaid
 flowchart LR
-  Browser["Browser<br/>(rendered HTML + textarea)"]
+  Browser["Browser<br/>(React reader + CodeMirror source mode)"]
 
   subgraph Server["Miku — Rust single binary"]
     HTTP["axum HTTP layer<br/>(read-only on index)"]
@@ -38,9 +38,9 @@ flowchart LR
   Indexer -->|"reindex tx"| PG
 ```
 
-## 2. Rendering model — view vs edit (v0)
+## 2. Rendering model — reader vs source mode
 
-The readonly rendered view is the **primary** mode; editing is opt-in. Classic wiki model, no client JS.
+The React reader is the **primary** mode; CodeMirror source editing is opt-in and loaded lazily.
 
 ```mermaid
 flowchart TD
@@ -49,7 +49,7 @@ flowchart TD
   X -- no --> NEW["offer: create Foo?"]
 
   RO -->|"click Edit"| E["PUT /api/v1/notes/Foo.md"]
-  E --> T["read Foo.md -> textarea"]
+  E --> T["load CodeMirror source editor"]
   T -->|"Save"| P["PUT /api/v1/notes/Foo.md"]
   P --> S["atomic save"]
   S --> RD["watcher reindexes Foo.md"]
@@ -67,7 +67,7 @@ sequenceDiagram
   participant FS as miku_docs/*.md
   participant W as notify watcher
   participant I as Indexer
-  participant PG as Postgres
+  participant PG as Index projection
 
   B->>H: PUT /api/v1/notes/Foo.md (markdown body + revision)
   H->>FS: write Foo.md.tmp + fsync (miku_docs/)
@@ -83,7 +83,7 @@ sequenceDiagram
 
 ## 4. Reindex-one-page transaction
 
-One page reindex is a single Postgres transaction.
+One page reindex is one backend transaction. SQLite is the default; Postgres uses the same writer contract in its optional profile.
 
 ```mermaid
 flowchart TD
@@ -128,7 +128,7 @@ stateDiagram-v2
 
 ## 7. Read-path queries (no filesystem touch)
 
-Backlinks, tags, and search read **only** Postgres — never the filesystem — and are paginated so the full edge set is never loaded at once.
+Backlinks, tags, and search read **only** the selected index projection—SQLite by default—never the filesystem.
 
 ```mermaid
 flowchart LR
@@ -137,7 +137,7 @@ flowchart LR
     TG["GET /api/v1/tags/:tag/notes"]
     SR["GET /api/v1/search?q="]
   end
-  BL -->|"links.target_id = Foo.id<br/>LIMIT/OFFSET"| PG[("Postgres")]
+  BL -->|"indexed backlinks"| PG[("SQLite / selected projection")]
   TG -->|"tags.tag = :tag"| PG
   SR -->|"body_tsv @@ query (GIN)"| PG
 ```

--- a/miku_docs/features.md
+++ b/miku_docs/features.md
@@ -1,5 +1,7 @@
 ---
 title: Miku Note Features
+aliases:
+  - Features
 type: guide
 status: active
 tags: [miku, features, markdown]
@@ -83,7 +85,7 @@ source.
 
 ## Wikilinks, backlinks, and mentions
 
-Write `[[PageName]]` to connect notes. Matching is case-insensitive, and links can include a display alias such as `[[Index|Home]]`.
+Write `[[PageName]]` to connect notes. Matching is case-insensitive, and links can include a display alias such as `[[index|Home]]`.
 
 When a note links to another note, the target page shows explicit backlinks. Each backlink shows the source note title and path and opens that source note; the indexer also records plain-text mentions
 as a secondary discovery surface.
@@ -147,4 +149,4 @@ The following items remain outside the current feature set:
 - Dataview-style queries and daily-note/calendar workflows;
 - MDX/JSX as a Markdown rendering requirement.
 
-For a hands-on compatibility page, see [[Sandbox]]. For setup instructions, see [[Usage]].
+For a hands-on compatibility page, see [[sandbox|Sandbox]]. For setup instructions, see [[usage|Usage]].

--- a/miku_docs/index.md
+++ b/miku_docs/index.md
@@ -1,5 +1,7 @@
 ---
 title: Miku Note
+aliases:
+  - Index
 type: index
 status: active
 tags: [miku, guide]
@@ -21,10 +23,10 @@ tags, mentions, and search. #docs #feature
 
 ## Start here
 
-- [[Features]] — the current feature inventory and scope boundary.
-- [[Usage]] — local setup, content paths, and the development commands.
-- [[Sandbox]] — live examples of Markdown, diagrams, code, math, and links.
-- [[Changelog]] — shipped and in-progress product changes. #release
+- [[features|Features]] — the current feature inventory and scope boundary.
+- [[usage|Usage]] — local setup, content paths, and the development commands.
+- [[sandbox|Sandbox]] — live examples of Markdown, diagrams, code, math, and links.
+- [[changelog|Changelog]] — shipped and in-progress product changes. #release
 
 ## Project knowledge
 
@@ -33,7 +35,7 @@ tags, mentions, and search. #docs #feature
 - [[setup]] — local development, backends, and verification commands.
 - [[runtime-workflow]] — how filesystem changes become reader state.
 - [[product]] — product direction and UX constraints.
-- [[adr/README]] — verified ADR index; individual records live below `adr/`.
+- [[adr/readme|Architecture Decision Records]] — verified ADR index; individual records live below `adr/`.
 - [[api]] — current JSON and browser route contract.
 
 ## Core invariant
@@ -42,4 +44,4 @@ tags, mentions, and search. #docs #feature
 
 ## Release history
 
-The original MVP shipped as v0.0.1. The current working line is the Miku Note frontend and reader refresh; see [[Changelog]] for the details and status.
+The original MVP shipped as v0.0.1. The current working line is the Miku Note frontend and reader refresh; see [[changelog|Changelog]] for the details and status.

--- a/miku_docs/kb-conventions.md
+++ b/miku_docs/kb-conventions.md
@@ -1,0 +1,121 @@
+---
+title: KB conventions
+created: 2026-07-21 19:17
+modified: 2026-07-21 19:17
+type: documentation
+status: maintained
+maturity: stable
+tags:
+  - meta
+  - documentation
+---
+
+# KB conventions
+
+Miku's tracked first-party notes are the source of truth. These conventions apply to Markdown files directly under `miku_docs/` and `miku_docs/adr/`. Imported course corpora are preserved as source material and are not renamed or semantically normalized.
+
+## Frontmatter
+
+Every note should have these fields:
+
+```yaml
+---
+title: A descriptive title
+created: YYYY-MM-DD HH:MM
+modified: YYYY-MM-DD HH:MM
+type: concept
+status: active
+maturity: seed
+aliases:
+  - optional-alias
+tags:
+  - optional-tag
+---
+```
+
+Required fields are `title`, `created`, `modified`, `type`, `status`, `maturity`, and `tags`.
+
+`type` answers “what is this?” Use one of:
+
+- `concept`, `article`, `book`, `course`, `collection`, or `person` for knowledge notes
+- `journal`, `inbox`, `map`, `plan`, `index`, or `documentation` for operational notes
+
+`status` answers “what am I doing with it?” The supported workflow values are:
+
+- `inbox`: captured but not processed
+- `active`: currently being processed or developed
+- `paused`: intentionally deprioritized
+- `maintained`: stable enough to keep and occasionally review
+
+`maturity` answers “how developed is the knowledge?” The supported values are:
+
+- `seed`: an initial capture or incomplete understanding
+- `developing`: useful, but still being expanded or clarified
+- `stable`: coherent knowledge that does not currently need substantial work
+
+Additional fields such as `source`, `author`, `aliases`, `date`, and book-specific metadata are allowed when they describe the note. Avoid introducing presentation-only or duplicate fields.
+
+Frontmatter uses the canonical order shown above, followed by optional descriptive, publishing, progress, and finally unknown fields. Sequence values use block-list syntax (`  - value`), never flow syntax (`[value]`). Historical daily activity-hour mappings use `time_spent`; the misleading `timer` key and Tolaria's `_width` and `_organized` presentation keys are not supported.
+
+Frontmatter migration is intentionally reviewable rather than automatic. Run `make kb-check` to validate maintained filenames and local-link casing.
+
+### Filenames and aliases
+
+- Markdown filenames use lowercase kebab-case, for example `cognitive-load-theory.md`. Daily notes use the ISO date form `YYYY-MM-DD.md`; weekly and monthly notes retain their existing ISO-derived forms such as `2026-w31.md` and `2026-07.md`.
+- A filename is a stable identifier, not a display title. Keep capitalization, punctuation, non-English names, and other human-readable forms in `title` or `aliases`.
+- When renaming a note, add the old stem as an alias unless it was meaningless or incorrect. Update resolvable repository links in the same change and run `make audit`.
+- Aliases represent names a reader might genuinely search for: former filenames, abbreviations, translations, or established alternate names. Do not add spelling mistakes, duplicate the title, or repeat an alias with different capitalization.
+- Imported non-canonical filenames are legacy inventory. Do not rename them as part of first-party maintenance.
+
+### Sources
+
+- Use `source` when a note summarizes, quotes, imports, or closely derives from an external work. Original journals, plans, and independently developed concept notes do not need a source merely to satisfy metadata.
+- Prefer the most direct durable URL available. If no URL exists, use a precise bibliographic reference or a wikilink to a source note.
+- Use `author` when attribution is known and useful. Keep source title, author, and publication details in the note body when a bare URL would not preserve enough context.
+- Mark quotations in the body and include a page, chapter, timestamp, or section when available. A `source` field identifies the work but does not replace local quotation context.
+- Never leave `source` as `todo`, `tbd`, `unknown`, or an empty field. Omit it until the provenance is known.
+
+### Tags
+
+Tags describe the note's subject or collection. They are not a copy of every keyword in the body.
+
+- Use one or more tags for every note. `status` remains the workflow field; do not use tags such as `#inbox` or `#active` as a replacement.
+- Tags use lowercase kebab-case without the `#` prefix in YAML, for example `cloud-native` or `personal-finance`. Words are separated by one hyphen; spaces and underscores are not canonical. Unicode letters and numbers are allowed, so non-English subject tags do not need transliteration.
+- Canonicalization trims surrounding whitespace, lowercases letters, replaces runs of whitespace, underscores, or hyphens with one hyphen, and removes leading or trailing hyphens. Unsupported punctuation is reported rather than silently deleted.
+- Prefer stable domain tags over narrow one-off phrases. Add a second tag only when it identifies a meaningful subdomain, format, or collection.
+- Do not encode dates or calendar periods in tags. Values such as `week-2026-31` duplicate journal filenames and are not useful subjects; use the note path, title, or date metadata for temporal queries.
+- Directory names are useful evidence but do not determine a tag by themselves; inspect the note title and content before assigning a topic.
+- Existing tags with legacy capitalization, spacing, or language are preserved until their note batch is reviewed. Normalize them only as part of an explicit batch.
+- Add tags in frontmatter rather than inline body tags so Obsidian searches and maintenance scripts have one canonical metadata source.
+- Use `tags` as the only subject-classification field. Do not add `categories`; `make frontmatter-format` migrates legacy category values into `tags`, and the tag formatter then canonicalizes them.
+
+Tag migration should remain reviewable. Canonical spelling is mechanical, but choosing, merging, or removing tag concepts requires inspecting the affected notes; do not make semantic taxonomy decisions as part of a filename-only change.
+
+## Titles and links
+
+- Journal titles include their date, for example `日志 2026.07.21`.
+- Weekly titles use `YYYY-wNN`.
+- Evergreen notes use a descriptive human title.
+- Prefer wikilinks for local notes and assets. Run `make kb-check` after renaming or deleting maintained notes.
+- Do not create a wikilink for an idea that does not yet have a note; use ordinary list text until the note exists.
+
+## Formatting and callouts
+
+Use native Obsidian callouts for notes, quotes, summaries, and warnings:
+
+```md
+> [!note]+ Note The first paragraph can contain multiple sentences on one physical line. If it is long, leave it long; Prettier will not hard-wrap it.
+>
+> Start a second paragraph with another quoted blank line.
+>
+> - Lists also need the `>` prefix.
+> - Keep the prefix on every physical line.
+```
+
+Callout content is a Markdown blockquote. Every physical line must begin with `> `, and blank lines inside the callout must be represented by a lone `>`. Without those prefixes, the content ends the callout.
+
+Use the repository's normal formatter for source code. Markdown body formatting remains manual so long prose and examples are not rewritten unexpectedly.
+
+## Maintenance
+
+Run `make kb-check` after changing maintained note filenames or links. The gate checks lowercase kebab-case names, unresolved Markdown links within the maintained set, and wikilinks that use non-canonical casing. `make check` includes this gate.

--- a/miku_docs/performance-baseline.md
+++ b/miku_docs/performance-baseline.md
@@ -3,12 +3,12 @@ title: Performance Baseline
 type: reference
 status: active
 tags: [miku, performance, benchmark]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Indexing performance baseline
 
-This document records the current 0.0.2 SQLite/SQLx profile. Historical backend measurements remain archival context.
+This document records the current 0.0.5 SQLite/SQLx profile. Historical backend measurements remain archival context.
 
 ## Corpus
 
@@ -20,13 +20,13 @@ This document records the current 0.0.2 SQLite/SQLx profile. Historical backend 
 
 ## Verified current properties
 
-- The local durable index is SQLite via SQLx with WAL mode, foreign keys, a five-second busy timeout, and SQLite FTS5.
+- The local durable index is SQLite via SQLx with WAL mode, foreign keys, a five-second busy timeout, and a plain `TEXT` body column searched in parallel Rust code.
 - The index is disposable and rebuilt from `miku_docs/**/*.md`.
-- Page, link, tag, alias, mention, and FTS writes are transactional at the backend boundary.
+- Page, link, tag, alias, mention, and body writes are transactional at the backend boundary.
 - HTTP reads use the backend-neutral `IndexReader` contract; the filesystem remains the source of truth.
-- The default backend is selected with `MIKU_INDEX_BACKEND=memory` and uses the rebuildable memory/Tantivy projection; SQLite remains available with `MIKU_INDEX_BACKEND=sqlite`.
+- The default backend is `MIKU_INDEX_BACKEND=sqlite`. MemoryIndex supplies the rebuildable graph projection; SQLite serves search regardless of graph readiness.
 
-## Dependency closure
+## Historical dependency closure (0.0.2)
 
 The migration reduced the root package's normal dependency tree from 403 unique packages to 254, a reduction of 149 packages (36.9%). The complete lockfile resolution fell from 482 package records to
 312, a reduction of 170 records (35.3%). Both figures count the complete resolved dependency set, including transitive packages.

--- a/miku_docs/product.md
+++ b/miku_docs/product.md
@@ -3,7 +3,7 @@ title: Miku Product
 type: product
 status: active
 tags: [miku, product, local-first]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Miku — Product & Positioning
@@ -33,7 +33,7 @@ disposable. Audit is `git log` over the notes directory.
 Notes across five courses; the connections exams test get lost. Tags `#thermodynamics`, links `[[entropy]]`. Two weeks before finals she revises by _following the graph_ through backlinks instead of
 re-reading everything.
 
-- **Leans on:** tags, backlinks-as-revision-tool, dead-simple textarea capture.
+- **Leans on:** tags, backlinks-as-revision-tool, and explicit Markdown source editing.
 - **Before:** linear Google Docs; no way to see how concepts connected.
 
 ### 4. Lucas — freelance investigative journalist
@@ -56,7 +56,7 @@ Manuscript and wiki are the same plain files.
 
 | Tension from the stories                                                      | Design response                                                                                               |
 | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Mei & Lucas need frictionless capture                                         | Keep v0 textarea, but make **quick-create / quick-open (fuzzy by title)** a first-class flow.                 |
+| Mei & Lucas need frictionless capture                                         | Keep source editing explicit and make **quick-open (title/content)** a first-class flow.                      |
 | Aiko & Lucas have large, dense graphs                                         | Non-negotiable: never recompute the graph on a keystroke; paginate/virtualize backlinks.                      |
 | Tanaka-san needs the rebuildable-index promise _provable_                     | "Drop DB → rebuild from files" is a real command someone can run — that demo _is_ the compliance sale.        |
 | Everyone also edits files outside the editor (git pull, sed, another machine) | The `notify` watcher as the sole index trigger makes external edits reindex identically. Single-writer holds. |
@@ -74,10 +74,10 @@ grep, your editor, your backup) can't touch the data.
 
 - **You own the files.** Plain `.md` in one folder. Delete Miku tomorrow; your knowledge is untouched.
 - **Connections, found for you.** `[[links]]` → backlinks, tags, FTS built in the background. The valuable graph, without hand-maintenance.
-- **The projections are disposable, on purpose.** Memory/Tantivy is the local default and SQLite/Postgres are optional; nuke any projection and Miku rebuilds from files. Nothing important lives
-  anywhere but your disk.
+- **The projections are disposable, on purpose.** SQLite search and the MemoryIndex graph are local derived state; Postgres remains optional. Delete a projection and Miku rebuilds it from files.
+  Nothing important lives anywhere but your disk.
 - **Self-host or run local.** No account, no telemetry, no cloud.
-- **It gets out of your way.** Browser editor over a textarea. No bundler, no app to learn, no migration the day you need it most.
+- **It gets out of your way.** The React workspace keeps reading primary and opens CodeMirror source editing only when requested.
 
 **One line:** _Obsidian's linking and a real search engine — but the files are unarguably yours, and the index is something you can throw away._
 

--- a/miku_docs/sandbox.md
+++ b/miku_docs/sandbox.md
@@ -1,5 +1,7 @@
 ---
 title: Markdown Sandbox
+aliases:
+  - Sandbox
 type: sandbox
 status: active
 tags: [miku, demo, markdown]
@@ -63,19 +65,19 @@ $$
 
 Miku Note uses wikilinks to connect your notes into a network. Try clicking these links:
 
-- [[Index]] — the main landing page and entry point to the wiki.
-- [[Features]] — a detailed walkthrough of each Miku capability.
-- [[Usage]] — how to set up and run Miku Note locally.
-- [[Changelog]] — release notes and version history.
+- [[index|Miku Note]] — the main landing page and entry point to the wiki.
+- [[features|Features]] — a detailed walkthrough of each Miku capability.
+- [[usage|Usage]] — how to set up and run Miku Note locally.
+- [[changelog|Changelog]] — release notes and version history.
 
-You can also use link text overrides: [[Index|Back to Home]] displays as "Back to Home" but links to [[Index]].
+You can also use link text overrides: [[index|Back to Home]] displays as "Back to Home" but links to [[index|Miku Note]].
 
 ## Tags in Context
 
 This page uses the #demo tag to mark it as a playground for new users. Other pages use #feature, #guide, #docs, and #release to organize content by type. Browse the tag index to see how pages cluster.
 #demo
 
-The [[Features]] page discusses tags in detail — how they're extracted, indexed, and used to filter and explore your wiki.
+The [[features|Features]] page discusses tags in detail — how they're extracted, indexed, and used to filter and explore your wiki.
 
 ## What Next?
 
@@ -83,11 +85,13 @@ Explore the wiki:
 
 1. Click through the wikilinks above to see backlinks in action.
 2. Use content search (top of the page) to find phrases like "atomic saves" or "background indexer". The same search is available in the Content tab of `Cmd-K`.
-3. Browse the [[Index]] to see the wiki structure.
-4. Read [[Features]] to understand how wikilinks, tags, and backlinks work behind the scenes.
+3. Browse the [[index|Miku Note]] to see the wiki structure.
+4. Read [[features|Features]] to understand how wikilinks, tags, and backlinks work behind the scenes.
 
-For hands-on setup instructions, see [[Usage]]. For historical context and version information, see [[Changelog]].
+For hands-on setup instructions, see [[usage|Usage]]. For historical context and version information, see [[changelog|Changelog]].
 
 ---
 
 Happy wiki writing!
+
+it's my not fault to do the thing.

--- a/miku_docs/setup.md
+++ b/miku_docs/setup.md
@@ -3,7 +3,7 @@ title: Miku Development Setup
 type: guide
 status: active
 tags: [miku, setup, development]
-updated: 2026-07-16
+updated: 2026-07-29
 ---
 
 # Setup
@@ -15,13 +15,13 @@ updated: 2026-07-16
 
 ## Native dev stack (no containers — Linux & macOS)
 
-The default path is SQLite durability with a MemoryIndex/Tantivy hot projection:
+The default path uses SQLite for durable metadata and full-text search, plus MemoryIndex for the rebuildable in-process graph:
 
 ```bash
 make dev
 ```
 
-The default runtime uses SQLite plus the in-memory/Tantivy projection. Postgres and Valkey are optional service-backed profiles.
+Postgres and Valkey remain optional service-backed profiles. Tantivy is not part of the current runtime.
 
 Override the backend with MIKU_INDEX_BACKEND, DATABASE_URL, or VALKEY_URL.
 

--- a/miku_docs/usage.md
+++ b/miku_docs/usage.md
@@ -1,5 +1,7 @@
 ---
 title: Using Miku Note
+aliases:
+  - Usage
 type: guide
 status: active
 tags: [miku, guide, setup]
@@ -39,11 +41,11 @@ The compose service uses Postgres and exposes Miku Note on port `3000`.
 Pages live under `miku_docs/` and are plain Markdown files. For example:
 
 ```text
-miku_docs/Features.md
+miku_docs/features.md
 miku_docs/guides/Getting Started.md
 ```
 
-They are available at `/p/Features.md` and `/p/guides/Getting%20Started.md`. Wikilink matching is case-insensitive and supports aliases: `[[Features|What it does]]`.
+They are available at `/p/features.md` and `/p/guides/Getting%20Started.md`. Wikilink matching is case-insensitive and supports aliases: `[[features|What it does]]`.
 
 Miku does not create a Trash directory. Assets belong in `miku_docs/assets/`; path changes and file removal remain ordinary filesystem operations outside the v0.0.2 UI.
 
@@ -55,7 +57,7 @@ Miku Note uses Comrak with GFM-style tables, task lists, strikethrough, autolink
 - fenced code blocks, Mermaid diagrams, and `$...$` / `$$...$$` math;
 - `![[asset.png]]` embeds.
 
-See [[Sandbox]] for examples and [[Features]] for the complete current list.
+See [[sandbox|Sandbox]] for examples and [[features|Features]] for the complete current list.
 
 ## Editing and external changes
 

--- a/scripts/blackbox.py
+++ b/scripts/blackbox.py
@@ -146,7 +146,9 @@ def main() -> int:
     print(f"ok: search latency={search_latency_ms:.2f}ms (<200ms)")
 
     # Tags & Tag Notes
-    tags = json_get("/api/v1/tags")
+    tags = json_get("/api/v1/tags?limit=50&offset=0")
+    if len(tags) > 50:
+        raise AssertionError("tag endpoint ignored its page limit")
     if tags:
         tag = urllib.parse.quote(tags[0]["tag"], safe="")
         json_get(f"/api/v1/tags/{tag}/notes")

--- a/scripts/check_kb_conventions.py
+++ b/scripts/check_kb_conventions.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Check conventions for Miku's maintained first-party knowledge base."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "miku_docs"
+KEBAB_NAME = re.compile(r"^(?:\d{4}-)?[a-z0-9]+(?:-[a-z0-9]+)*\.md$")
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+\.md)(?:#[^)]*)?\)")
+WIKILINK = re.compile(r"\[\[([^]|#]+)")
+
+
+def maintained_notes() -> list[Path]:
+    notes = list(DOCS.glob("*.md"))
+    notes.extend((DOCS / "adr").glob("*.md"))
+    return sorted(notes)
+
+
+def main() -> int:
+    notes = maintained_notes()
+    relative_paths = {note.relative_to(DOCS).as_posix() for note in notes}
+    errors: list[str] = []
+
+    for note in notes:
+        relative = note.relative_to(ROOT).as_posix()
+        if not KEBAB_NAME.fullmatch(note.name):
+            errors.append(f"{relative}: filename must be lowercase kebab-case")
+
+        text = note.read_text(encoding="utf-8")
+        for target in MARKDOWN_LINK.findall(text):
+            if "://" in target:
+                continue
+            resolved = (note.parent / target).resolve()
+            try:
+                target_relative = resolved.relative_to(DOCS.resolve()).as_posix()
+            except ValueError:
+                continue
+            if target_relative not in relative_paths:
+                errors.append(f"{relative}: unresolved Markdown link {target!r}")
+
+        for target in WIKILINK.findall(text):
+            parent = note.parent.relative_to(DOCS).as_posix()
+            candidate = f"{parent}/{target}.md".removeprefix("./")
+            if candidate not in relative_paths:
+                candidate = f"{target}.md"
+            if candidate in relative_paths:
+                continue
+            matches = [path for path in relative_paths if path.casefold() == candidate.casefold()]
+            if matches:
+                errors.append(
+                    f"{relative}: wikilink {target!r} must use canonical target {matches[0][:-3]!r}"
+                )
+
+    if errors:
+        print("KB convention check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"KB convention check passed ({len(notes)} maintained notes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -52,8 +52,9 @@ def main() -> int:
         page.locator(".note-scroll h1").filter(has_text="Sandbox").first.wait_for()
         if page.locator(".note-scroll h1").first.inner_text() != "Markdown Sandbox":
             raise AssertionError("clicking a note did not update the reader")
-        if page.locator(".note-meta-tags .tag", has_text="#demo").count() != 1:
-            raise AssertionError("sandbox inline tag is missing from note metadata")
+        frontmatter_tags = page.locator(".frontmatter-panel .tag").all_inner_texts()
+        if frontmatter_tags != ["#miku", "#demo", "#markdown"]:
+            raise AssertionError("sandbox frontmatter tags do not match the YAML source")
         if page.locator(".context-title", has_text="Tags").count() != 0:
             raise AssertionError("tags are duplicated in the Context panel")
         backlink_text = "\n".join(page.locator(".backlink-row").all_inner_texts())
@@ -74,7 +75,7 @@ def main() -> int:
             raise AssertionError("sandbox math did not render")
         if page.locator('a[href="/tags/demo"]').count() < 1:
             raise AssertionError("sandbox inline tag link is missing")
-        page.locator(".note-meta-tags .tag", has_text="#demo").click()
+        page.locator(".frontmatter-panel .tag", has_text="#demo").click()
         page.wait_for_url("**/tags/demo")
         page.get_by_role("button", name="Markdown Sandbox", exact=True).first.wait_for()
         page.goto(f"{BASE_URL}/p/Sandbox.md", wait_until="domcontentloaded")
@@ -184,6 +185,14 @@ def main() -> int:
             if mobile_nav.get_attribute("aria-expanded") != "false":
                 raise AssertionError("mobile workspace navigation did not close after navigation")
             page.wait_for_timeout(250)
+        open_tabs = page.locator(".tab")
+        tab_count = open_tabs.count()
+        page.locator(".tab.is-active .tab-close").click()
+        page.wait_for_url("**/p/Changelog.md")
+        if open_tabs.count() != tab_count - 1:
+            raise AssertionError("closing the active navigation tab reopened it")
+        if page.get_by_role("tab", name=re.compile("Markdown Sandbox")).count() != 0:
+            raise AssertionError("closed navigation tab remains visible")
         mobile_nav.click()
         page.keyboard.press("Escape")
         if mobile_nav.get_attribute("aria-expanded") != "false":

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -105,8 +105,12 @@ def main() -> int:
         page.get_by_role("button", name="Collapse workspace tree").click()
         if page.locator(".tree-row").filter(has_text=NOTE_TITLE).count() != 0:
             raise AssertionError("collapsed workspace tree still shows descendants")
-        page.get_by_role("button", name="Expand workspace tree").click()
+        nested_folder.click()
         page.locator(".tree-row").filter(has_text=NOTE_TITLE).first.wait_for()
+        if page.get_by_role("button", name="Collapse workspace tree").count() != 1:
+            raise AssertionError(
+                "clicking an expanded root did not reopen the globally collapsed tree"
+            )
 
         theme = page.locator(".app-shell").get_attribute("data-theme")
         dark_background = page.locator(".app-shell").evaluate(

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 from playwright.sync_api import Page, sync_playwright
@@ -149,16 +150,47 @@ def main() -> int:
         page.wait_for_url("**/p/Features.md")
 
         page.set_viewport_size({"width": 390, "height": 844})
-        for path in ("Index.md", "Usage.md", "Changelog.md", "Sandbox.md"):
-            title = path.removesuffix(".md")
-            page.locator(".tree-row").filter(has_text=title).last.click()
+        page.wait_for_timeout(200)
+        mobile_nav = page.locator(".mobile-nav-toggle")
+        mobile_nav.wait_for()
+        if mobile_nav.get_attribute("aria-label") != "Open workspace navigation":
+            raise AssertionError("mobile workspace navigation trigger is not labelled")
+        if mobile_nav.get_attribute("aria-expanded") != "false":
+            raise AssertionError("mobile workspace navigation is not closed by default")
+        sidebar = page.locator("#workspace-navigation")
+        sidebar_box = sidebar.bounding_box()
+        if sidebar_box and sidebar_box["x"] >= 0:
+            raise AssertionError("closed mobile workspace navigation remains on canvas")
+        for path, title in (
+            ("Index.md", "Miku Note"),
+            ("Usage.md", "Using Miku Note"),
+            ("Changelog.md", "Changelog"),
+            ("Sandbox.md", "Markdown Sandbox"),
+        ):
+            mobile_nav.click()
+            page.get_by_role("button", name="Close workspace navigation").last.wait_for()
+            if mobile_nav.get_attribute("aria-expanded") != "true":
+                raise AssertionError("mobile workspace navigation did not expose expanded state")
+            exact_label = page.locator(".tree-label", has_text=re.compile(f"^{re.escape(title)}$"))
+            page.locator(".tree-row").filter(has=exact_label).last.click()
             page.wait_for_url(f"**/p/{path}")
+            mobile_nav.wait_for()
+            if mobile_nav.get_attribute("aria-expanded") != "false":
+                raise AssertionError("mobile workspace navigation did not close after navigation")
             page.wait_for_timeout(250)
+        mobile_nav.click()
+        page.keyboard.press("Escape")
+        if mobile_nav.get_attribute("aria-expanded") != "false":
+            raise AssertionError("Escape did not close mobile workspace navigation")
+        if not mobile_nav.evaluate("element => element === document.activeElement"):
+            raise AssertionError("closing mobile workspace navigation did not restore focus")
         tabs = page.locator(".tabs")
         if tabs.evaluate("el => getComputedStyle(el).overflowX") not in ("auto", "scroll"):
             raise AssertionError("open tabs are not horizontally scrollable")
         if not tabs.evaluate("el => el.scrollWidth > el.clientWidth"):
             raise AssertionError("multiple open tabs did not overflow horizontally")
+        page.set_viewport_size({"width": 1440, "height": 900})
+        page.wait_for_timeout(200)
 
         page.goto(f"{BASE_URL}/p/does-not-exist.md", wait_until="domcontentloaded")
         page.wait_for_url(f"{BASE_URL}/p/Index.md", timeout=10_000)
@@ -184,7 +216,7 @@ def main() -> int:
         page.screenshot(path=str(ARTIFACT_DIR / "reading.png"), full_page=True)
         page.set_viewport_size({"width": 390, "height": 844})
         page.reload(wait_until="domcontentloaded")
-        page.get_by_text("All notes").wait_for()
+        page.locator(".mobile-nav-toggle").wait_for()
         if page.locator("body").evaluate("el => el.scrollWidth > el.clientWidth"):
             raise AssertionError("narrow viewport has horizontal overflow")
         page.screenshot(path=str(ARTIFACT_DIR / "narrow.png"), full_page=True)

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -114,12 +114,18 @@ def main() -> int:
             )
 
         theme = page.locator(".app-shell").get_attribute("data-theme")
+        favicon = page.locator("#miku-favicon")
+        if not favicon.get_attribute("href").endswith(f"/miku-icon-{theme}.svg"):
+            raise AssertionError("favicon does not match the active shell theme")
         dark_background = page.locator(".app-shell").evaluate(
             "el => getComputedStyle(el).backgroundColor"
         )
         page.get_by_role("button", name="Toggle theme").click()
-        if page.locator(".app-shell").get_attribute("data-theme") == theme:
+        toggled_theme = page.locator(".app-shell").get_attribute("data-theme")
+        if toggled_theme == theme:
             raise AssertionError("theme toggle did not change the shell theme")
+        if not favicon.get_attribute("href").endswith(f"/miku-icon-{toggled_theme}.svg"):
+            raise AssertionError("favicon did not follow the shell theme toggle")
         light_background = page.locator(".app-shell").evaluate(
             "el => getComputedStyle(el).backgroundColor"
         )

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -155,6 +155,10 @@ def main() -> int:
         quick_search.press("ArrowDown")
         quick_search.press("Enter")
         page.wait_for_url("**/p/Features.md")
+        page.get_by_role("button", name="Open quick search").click()
+        if page.get_by_label("Quick search input").input_value() != "":
+            raise AssertionError("quick search retained its previous query after navigation")
+        page.keyboard.press("Escape")
 
         page.set_viewport_size({"width": 390, "height": 844})
         page.wait_for_timeout(200)

--- a/scripts/ux_browser.py
+++ b/scripts/ux_browser.py
@@ -48,7 +48,7 @@ def main() -> int:
         if page.locator(".tree-row").filter(has_text="architecture").count() != 1:
             raise AssertionError("migrated architecture note is missing from the vault tree")
         page.locator(".tree-row").filter(has_text="Sandbox").click()
-        page.wait_for_url("**/p/Sandbox.md")
+        page.wait_for_url("**/p/sandbox.md")
         page.locator(".note-scroll h1").filter(has_text="Sandbox").first.wait_for()
         if page.locator(".note-scroll h1").first.inner_text() != "Markdown Sandbox":
             raise AssertionError("clicking a note did not update the reader")
@@ -61,7 +61,7 @@ def main() -> int:
         for source in ("Changelog", "Features", "Index", "Usage"):
             if source not in backlink_text:
                 raise AssertionError(f"Sandbox is missing its self-doc backlink from {source}")
-        if "Sandbox.md" in backlink_text:
+        if "sandbox.md" in backlink_text:
             raise AssertionError("a note must not list itself as a backlink")
         if (
             page.locator(".markdown-alert-note").count() != 1
@@ -78,7 +78,7 @@ def main() -> int:
         page.locator(".frontmatter-panel .tag", has_text="#demo").click()
         page.wait_for_url("**/tags/demo")
         page.get_by_role("button", name="Markdown Sandbox", exact=True).first.wait_for()
-        page.goto(f"{BASE_URL}/p/Sandbox.md", wait_until="domcontentloaded")
+        page.goto(f"{BASE_URL}/p/sandbox.md", wait_until="domcontentloaded")
         page.locator(".toc-item").first.click()
         if "#" not in page.url:
             raise AssertionError("TOC click did not update the URL fragment")
@@ -154,7 +154,7 @@ def main() -> int:
         page.locator("#quick-open-results [role='option']").first.wait_for()
         quick_search.press("ArrowDown")
         quick_search.press("Enter")
-        page.wait_for_url("**/p/Features.md")
+        page.wait_for_url("**/p/features.md")
         page.get_by_role("button", name="Open quick search").click()
         if page.get_by_label("Quick search input").input_value() != "":
             raise AssertionError("quick search retained its previous query after navigation")
@@ -173,10 +173,10 @@ def main() -> int:
         if sidebar_box and sidebar_box["x"] >= 0:
             raise AssertionError("closed mobile workspace navigation remains on canvas")
         for path, title in (
-            ("Index.md", "Miku Note"),
-            ("Usage.md", "Using Miku Note"),
-            ("Changelog.md", "Changelog"),
-            ("Sandbox.md", "Markdown Sandbox"),
+            ("index.md", "Miku Note"),
+            ("usage.md", "Using Miku Note"),
+            ("changelog.md", "Changelog"),
+            ("sandbox.md", "Markdown Sandbox"),
         ):
             mobile_nav.click()
             page.get_by_role("button", name="Close workspace navigation").last.wait_for()
@@ -192,7 +192,7 @@ def main() -> int:
         open_tabs = page.locator(".tab")
         tab_count = open_tabs.count()
         page.locator(".tab.is-active .tab-close").click()
-        page.wait_for_url("**/p/Changelog.md")
+        page.wait_for_url("**/p/changelog.md")
         if open_tabs.count() != tab_count - 1:
             raise AssertionError("closing the active navigation tab reopened it")
         if page.get_by_role("tab", name=re.compile("Markdown Sandbox")).count() != 0:
@@ -212,9 +212,9 @@ def main() -> int:
         page.wait_for_timeout(200)
 
         page.goto(f"{BASE_URL}/p/does-not-exist.md", wait_until="domcontentloaded")
-        page.wait_for_url(f"{BASE_URL}/p/Index.md", timeout=10_000)
+        page.wait_for_url(f"{BASE_URL}/p/index.md", timeout=10_000)
         page.get_by_role("alert").filter(has_text="Note not found").wait_for()
-        page.goto(f"{BASE_URL}/p/Sandbox.md", wait_until="domcontentloaded")
+        page.goto(f"{BASE_URL}/p/sandbox.md", wait_until="domcontentloaded")
         page.locator(".note-scroll h1").filter(has_text="Sandbox").first.wait_for()
         page.goto(f"{BASE_URL}/tags/not-a-real-tag", wait_until="domcontentloaded")
         page.get_by_role("heading", name="#not-a-real-tag").wait_for()

--- a/scripts/ux_smoke.py
+++ b/scripts/ux_smoke.py
@@ -54,8 +54,8 @@ def main() -> int:
         raise AssertionError("workspace tree has no root nodes")
     expect(get("/api/v1/tree?folder=dedao-docs")[0], {200}, "/api/v1/tree folder")
 
-    status, content_type, body = get("/api/v1/notes/Index.md")
-    expect(status, {200}, "/api/v1/notes/Index.md")
+    status, content_type, body = get("/api/v1/notes/index.md")
+    expect(status, {200}, "/api/v1/notes/index.md")
     title = json.loads(body)["title"]
     if "application/json" not in content_type or title not in ("Index", "Miku Note"):
         raise AssertionError("note API did not return the Index contract")
@@ -70,7 +70,7 @@ def main() -> int:
     expect(get("/api/v1/tags")[0], {200}, "/api/v1/tags")
     expect(get("/api/openapi.json")[0], {200}, "/api/openapi.json")
 
-    page_paths = ["Index.md", "Changelog.md", "Features.md", "Usage.md"]
+    page_paths = ["index.md", "changelog.md", "features.md", "usage.md"]
 
     started = time.monotonic()
     with ThreadPoolExecutor(max_workers=6) as pool:

--- a/scripts/ux_soak.py
+++ b/scripts/ux_soak.py
@@ -16,10 +16,10 @@ TIMEOUT = float(os.environ.get("MIKU_UX_SOAK_TIMEOUT_SECONDS", "10"))
 MAX_P95 = float(os.environ.get("MIKU_UX_SOAK_MAX_P95_SECONDS", "5"))
 
 PAGE_PATHS = (
-    "Index.md",
-    "Changelog.md",
-    "Features.md",
-    "Usage.md",
+    "index.md",
+    "changelog.md",
+    "features.md",
+    "usage.md",
 )
 
 


### PR DESCRIPTION
## Summary

- fix workspace tree ancestry, tab closing, search reset, and note link extraction
- bring mobile navigation and dark-theme polish into the milestone
- paginate tag loading and align the 0.0.5 documentation
- adopt lowercase canonical filenames for maintained knowledge-base notes

## Verification

- make check
- live API and browser smoke checks performed during implementation

## Notes

- supersedes the review scope of #10; #10 remains open and unchanged
